### PR TITLE
Reduce benchmarking matrix for functions

### DIFF
--- a/engine/benches/bench.rs
+++ b/engine/benches/bench.rs
@@ -204,19 +204,8 @@ fn bench_simple_string_function_comparison(c: &mut Criterion) {
                 implementation: FunctionImpl::new(lowercase),
             },
         )],
-        filters: &[
-            r#"lowercase(http.host) == "EXAMPLE.ORG""#,
-            r#"lowercase(http.host) == "example.org""#,
-            r#"lowercase(http.host) in { "EXAMPLE.ORG" "example.org" }"#,
-        ],
-        values: &[
-            "example.org",
-            "EXAMPLE.ORG",
-            "ExAmPlE.oRg",
-            "cloudflare.org",
-            "CLOUDFLARE.ORG",
-            "ClOuDfArE.oRg",
-        ],
+        filters: &[r#"lowercase(http.host) == "example.org""#],
+        values: &["example.org", "EXAMPLE.ORG"],
     }
     .run(c)
 }
@@ -250,19 +239,8 @@ fn bench_nested_string_function_comparison(c: &mut Criterion) {
                 },
             ),
         ],
-        filters: &[
-            r#"uppercase(lowercase(http.host)) == "EXAMPLE.ORG""#,
-            r#"uppercase(lowercase(http.host)) == "example.org""#,
-            r#"uppercase(lowercase(http.host)) in { "EXAMPLE.ORG" "example.org" }"#,
-        ],
-        values: &[
-            "example.org",
-            "EXAMPLE.ORG",
-            "ExAmPlE.oRg",
-            "cloudflare.org",
-            "CLOUDFLARE.ORG",
-            "ClOuDfArE.oRg",
-        ],
+        filters: &[r#"uppercase(lowercase(http.host)) == "EXAMPLE.ORG""#],
+        values: &["example.org", "EXAMPLE.ORG"],
     }
     .run(c)
 }

--- a/engine/benches/bench.rs
+++ b/engine/benches/bench.rs
@@ -189,28 +189,7 @@ fn bench_string_matches(c: &mut Criterion) {
     }.run(c)
 }
 
-fn bench_simple_string_function_comparison(c: &mut Criterion) {
-    FieldBench {
-        field: "http.host",
-        functions: &[(
-            "lowercase",
-            Function {
-                args: vec![FunctionArg {
-                    arg_kind: FunctionArgKind::Field,
-                    val_type: Type::Bytes,
-                }],
-                opt_args: vec![],
-                return_type: Type::Bytes,
-                implementation: FunctionImpl::new(lowercase),
-            },
-        )],
-        filters: &[r#"lowercase(http.host) == "example.org""#],
-        values: &["example.org", "EXAMPLE.ORG"],
-    }
-    .run(c)
-}
-
-fn bench_nested_string_function_comparison(c: &mut Criterion) {
+fn bench_string_function_comparison(c: &mut Criterion) {
     FieldBench {
         field: "http.host",
         functions: &[
@@ -239,7 +218,10 @@ fn bench_nested_string_function_comparison(c: &mut Criterion) {
                 },
             ),
         ],
-        filters: &[r#"uppercase(lowercase(http.host)) == "EXAMPLE.ORG""#],
+        filters: &[
+            r#"lowercase(http.host) == "example.org""#,
+            r#"uppercase(lowercase(http.host)) == "EXAMPLE.ORG""#,
+        ],
         values: &["example.org", "EXAMPLE.ORG"],
     }
     .run(c)
@@ -253,8 +235,7 @@ criterion_group! {
         bench_int_comparisons,
         bench_string_comparisons,
         bench_string_matches,
-        bench_simple_string_function_comparison,
-        bench_nested_string_function_comparison,
+        bench_string_function_comparison,
 }
 
 criterion_main!(field_benchmarks);


### PR DESCRIPTION

These take forever and many don't measure the performance of function execution, but rather performance of other operators.

Let's reduce them only to isolated cases.