### PR TITLE
Rename "arg" in definitions to "param" 

### DIFF
--- a/engine/benches/bench.rs
+++ b/engine/benches/bench.rs
@@ -13,7 +13,7 @@ use criterion::{
 };
 use std::{clone::Clone, fmt::Debug, net::IpAddr};
 use wirefilter::{
-    ExecutionContext, Function, FunctionArg, FunctionArgKind, FunctionImpl, GetType, LhsValue,
+    ExecutionContext, Function, FunctionArgKind, FunctionImpl, FunctionParam, GetType, LhsValue,
     Scheme, Type,
 };
 
@@ -196,11 +196,11 @@ fn bench_string_function_comparison(c: &mut Criterion) {
             (
                 "lowercase",
                 Function {
-                    args: vec![FunctionArg {
+                    params: vec![FunctionParam {
                         arg_kind: FunctionArgKind::Field,
                         val_type: Type::Bytes,
                     }],
-                    opt_args: vec![],
+                    opt_params: vec![],
                     return_type: Type::Bytes,
                     implementation: FunctionImpl::new(lowercase),
                 },
@@ -208,11 +208,11 @@ fn bench_string_function_comparison(c: &mut Criterion) {
             (
                 "uppercase",
                 Function {
-                    args: vec![FunctionArg {
+                    params: vec![FunctionParam {
                         arg_kind: FunctionArgKind::Field,
                         val_type: Type::Bytes,
                     }],
-                    opt_args: vec![],
+                    opt_params: vec![],
                     return_type: Type::Bytes,
                     implementation: FunctionImpl::new(uppercase),
                 },

--- a/engine/examples/cli.rs
+++ b/engine/examples/cli.rs
@@ -2,7 +2,8 @@ extern crate wirefilter;
 
 use std::env::args;
 use wirefilter::{
-    Function, FunctionArg, FunctionArgKind, FunctionImpl, FunctionOptArg, LhsValue, Scheme, Type,
+    Function, FunctionArgKind, FunctionImpl, FunctionOptParam, FunctionParam, LhsValue, Scheme,
+    Type,
 };
 
 fn panic_function<'a>(_: &[LhsValue<'a>]) -> LhsValue<'a> {
@@ -25,11 +26,11 @@ fn main() {
         .add_function(
             "panic".into(),
             Function {
-                args: vec![FunctionArg {
+                params: vec![FunctionParam {
                     arg_kind: FunctionArgKind::Field,
                     val_type: Type::Bytes,
                 }],
-                opt_args: vec![FunctionOptArg {
+                opt_params: vec![FunctionOptParam {
                     arg_kind: FunctionArgKind::Literal,
                     default_value: "".into(),
                 }],

--- a/engine/src/ast/field_expr.rs
+++ b/engine/src/ast/field_expr.rs
@@ -308,7 +308,7 @@ mod tests {
     use ast::function_expr::{FunctionCallArgExpr, FunctionCallExpr};
     use cidr::{Cidr, IpCidr};
     use execution_context::ExecutionContext;
-    use functions::{Function, FunctionArg, FunctionArgKind, FunctionImpl, FunctionOptArg};
+    use functions::{Function, FunctionArgKind, FunctionImpl, FunctionOptParam, FunctionParam};
     use lazy_static::lazy_static;
     use rhs_types::IpRange;
     use std::net::IpAddr;
@@ -355,11 +355,11 @@ mod tests {
                 .add_function(
                     "echo".into(),
                     Function {
-                        args: vec![FunctionArg {
+                        params: vec![FunctionParam {
                             arg_kind: FunctionArgKind::Field,
                             val_type: Type::Bytes,
                         }],
-                        opt_args: vec![],
+                        opt_params: vec![],
                         return_type: Type::Bytes,
                         implementation: FunctionImpl::new(echo_function),
                     },
@@ -369,11 +369,11 @@ mod tests {
                 .add_function(
                     "lowercase".into(),
                     Function {
-                        args: vec![FunctionArg {
+                        params: vec![FunctionParam {
                             arg_kind: FunctionArgKind::Field,
                             val_type: Type::Bytes,
                         }],
-                        opt_args: vec![],
+                        opt_params: vec![],
                         return_type: Type::Bytes,
                         implementation: FunctionImpl::new(lowercase_function),
                     },
@@ -383,11 +383,11 @@ mod tests {
                 .add_function(
                     "concat".into(),
                     Function {
-                        args: vec![FunctionArg {
+                        params: vec![FunctionParam {
                             arg_kind: FunctionArgKind::Field,
                             val_type: Type::Bytes,
                         }],
-                        opt_args: vec![FunctionOptArg {
+                        opt_params: vec![FunctionOptParam {
                             arg_kind: FunctionArgKind::Literal,
                             default_value: "".into(),
                         }],

--- a/engine/src/ast/function_expr.rs
+++ b/engine/src/ast/function_expr.rs
@@ -1,6 +1,6 @@
 use super::field_expr::LhsFieldExpr;
 use execution_context::ExecutionContext;
-use functions::{Function, FunctionArg, FunctionArgKind};
+use functions::{Function, FunctionArgKind, FunctionParam};
 use lex::{expect, skip_space, take, take_while, LexError, LexErrorKind, LexResult, LexWith};
 use scheme::{Field, Scheme};
 use serde::Serialize;
@@ -32,25 +32,25 @@ impl<'s> FunctionCallArgExpr<'s> {
     }
 }
 
-struct SchemeFunctionArg<'s, 'a> {
+struct SchemeFunctionParam<'s, 'a> {
     scheme: &'s Scheme,
-    funcarg: &'a FunctionArg,
+    param: &'a FunctionParam,
     index: usize,
 }
 
-impl<'i, 's, 'a> LexWith<'i, SchemeFunctionArg<'s, 'a>> for FunctionCallArgExpr<'s> {
-    fn lex_with(input: &'i str, scheme_funcarg: SchemeFunctionArg<'s, 'a>) -> LexResult<'i, Self> {
+impl<'i, 's, 'a> LexWith<'i, SchemeFunctionParam<'s, 'a>> for FunctionCallArgExpr<'s> {
+    fn lex_with(input: &'i str, ctx: SchemeFunctionParam<'s, 'a>) -> LexResult<'i, Self> {
         let initial_input = input;
 
-        match scheme_funcarg.funcarg.arg_kind {
+        match ctx.param.arg_kind {
             FunctionArgKind::Field => {
-                let (lhs, input) = LhsFieldExpr::lex_with(input, scheme_funcarg.scheme)?;
-                if lhs.get_type() != scheme_funcarg.funcarg.val_type {
+                let (lhs, input) = LhsFieldExpr::lex_with(input, ctx.scheme)?;
+                if lhs.get_type() != ctx.param.val_type {
                     Err((
                         LexErrorKind::InvalidArgumentType {
-                            index: scheme_funcarg.index,
+                            index: ctx.index,
                             given: lhs.get_type(),
-                            expected: scheme_funcarg.funcarg.val_type,
+                            expected: ctx.param.val_type,
                         },
                         initial_input,
                     ))
@@ -59,8 +59,7 @@ impl<'i, 's, 'a> LexWith<'i, SchemeFunctionArg<'s, 'a>> for FunctionCallArgExpr<
                 }
             }
             FunctionArgKind::Literal => {
-                let (rhs_value, input) =
-                    RhsValue::lex_with(input, scheme_funcarg.funcarg.val_type)?;
+                let (rhs_value, input) = RhsValue::lex_with(input, ctx.param.val_type)?;
                 Ok((FunctionCallArgExpr::Literal(rhs_value), input))
             }
         }
@@ -94,7 +93,7 @@ impl<'s> FunctionCallExpr<'s> {
             .iter()
             .map(|arg| arg.execute(ctx))
             .chain(
-                self.function.opt_args[self.args.len() - self.function.args.len()..]
+                self.function.opt_params[self.args.len() - self.function.params.len()..]
                     .iter()
                     .map(|opt_arg| opt_arg.default_value.as_ref()),
             )
@@ -107,8 +106,8 @@ impl<'s> FunctionCallExpr<'s> {
 fn incompatible_number_arguments_err<'i>(function: &Function, input: &'i str) -> LexError<'i> {
     (
         LexErrorKind::IncompatibleNumberArguments {
-            expected_min: function.args.len(),
-            expected_max: function.args.len() + function.opt_args.len(),
+            expected_min: function.params.len(),
+            expected_max: function.params.len() + function.opt_params.len(),
         },
         input,
     )
@@ -134,7 +133,7 @@ impl<'i, 's> LexWith<'i, &'s Scheme> for FunctionCallExpr<'s> {
 
         let mut function_call = FunctionCallExpr::new(name, function);
 
-        for i in 0..function.args.len() {
+        for i in 0..function.params.len() {
             if i == 0 {
                 if take(input, 1)?.0 == ")" {
                     break;
@@ -148,9 +147,9 @@ impl<'i, 's> LexWith<'i, &'s Scheme> for FunctionCallExpr<'s> {
 
             let arg = FunctionCallArgExpr::lex_with(
                 input,
-                SchemeFunctionArg {
+                SchemeFunctionParam {
                     scheme,
-                    funcarg: &function.args[i],
+                    param: &function.params[i],
                     index: i,
                 },
             )?;
@@ -160,7 +159,7 @@ impl<'i, 's> LexWith<'i, &'s Scheme> for FunctionCallExpr<'s> {
             input = skip_space(arg.1);
         }
 
-        if function.args.len() != function_call.args.len() {
+        if function_call.args.len() != function.params.len() {
             return Err(incompatible_number_arguments_err(&function, input));
         }
 
@@ -169,28 +168,28 @@ impl<'i, 's> LexWith<'i, &'s Scheme> for FunctionCallExpr<'s> {
         while let Some(',') = input.chars().next() {
             input = skip_space(take(input, 1)?.1);
 
-            let opt_arg = function
-                .opt_args
+            let opt_param = function
+                .opt_params
                 .get(index)
                 .ok_or_else(|| incompatible_number_arguments_err(&function, input))?;
 
-            let arg_def = FunctionArg {
-                arg_kind: opt_arg.arg_kind.clone(),
-                val_type: opt_arg.default_value.get_type(),
+            let param = FunctionParam {
+                arg_kind: opt_param.arg_kind.clone(),
+                val_type: opt_param.default_value.get_type(),
             };
 
-            let arg = FunctionCallArgExpr::lex_with(
+            let (arg, rest) = FunctionCallArgExpr::lex_with(
                 input,
-                SchemeFunctionArg {
+                SchemeFunctionParam {
                     scheme,
-                    funcarg: &arg_def,
-                    index: function.args.len() + index,
+                    param: &param,
+                    index: function.params.len() + index,
                 },
             )?;
 
-            function_call.args.push(arg.0);
+            function_call.args.push(arg);
 
-            input = skip_space(arg.1);
+            input = skip_space(rest);
 
             index += 1;
         }
@@ -203,7 +202,7 @@ impl<'i, 's> LexWith<'i, &'s Scheme> for FunctionCallExpr<'s> {
 
 #[test]
 fn test_function() {
-    use functions::{FunctionImpl, FunctionOptArg};
+    use functions::{FunctionImpl, FunctionOptParam};
     use lazy_static::lazy_static;
     use scheme::UnknownFieldError;
     use types::Type;
@@ -224,11 +223,11 @@ fn test_function() {
                 .add_function(
                     "echo".into(),
                     Function {
-                        args: vec![FunctionArg {
+                        params: vec![FunctionParam {
                             arg_kind: FunctionArgKind::Field,
                             val_type: Type::Bytes,
                         }],
-                        opt_args: vec![FunctionOptArg {
+                        opt_params: vec![FunctionOptParam {
                             arg_kind: FunctionArgKind::Literal,
                             default_value: LhsValue::Int(10),
                         }],

--- a/engine/src/ast/function_expr.rs
+++ b/engine/src/ast/function_expr.rs
@@ -103,9 +103,9 @@ impl<'s> FunctionCallExpr<'s> {
     }
 }
 
-fn incompatible_number_arguments_err<'i>(function: &Function, input: &'i str) -> LexError<'i> {
+fn invalid_args_count<'i>(function: &Function, input: &'i str) -> LexError<'i> {
     (
-        LexErrorKind::IncompatibleNumberArguments {
+        LexErrorKind::InvalidArgumentsCount {
             expected_min: function.params.len(),
             expected_max: function.params.len() + function.opt_params.len(),
         },
@@ -140,7 +140,7 @@ impl<'i, 's> LexWith<'i, &'s Scheme> for FunctionCallExpr<'s> {
                 }
             } else {
                 input = expect(input, ",")
-                    .map_err(|(_, input)| incompatible_number_arguments_err(&function, input))?;
+                    .map_err(|(_, input)| invalid_args_count(&function, input))?;
             }
 
             input = skip_space(input);
@@ -160,7 +160,7 @@ impl<'i, 's> LexWith<'i, &'s Scheme> for FunctionCallExpr<'s> {
         }
 
         if function_call.args.len() != function.params.len() {
-            return Err(incompatible_number_arguments_err(&function, input));
+            return Err(invalid_args_count(&function, input));
         }
 
         let mut index = 0;
@@ -171,7 +171,7 @@ impl<'i, 's> LexWith<'i, &'s Scheme> for FunctionCallExpr<'s> {
             let opt_param = function
                 .opt_params
                 .get(index)
-                .ok_or_else(|| incompatible_number_arguments_err(&function, input))?;
+                .ok_or_else(|| invalid_args_count(&function, input))?;
 
             let param = FunctionParam {
                 arg_kind: opt_param.arg_kind.clone(),
@@ -267,7 +267,7 @@ fn test_function() {
 
     assert_err!(
         FunctionCallExpr::lex_with("echo ( );", &SCHEME),
-        LexErrorKind::IncompatibleNumberArguments {
+        LexErrorKind::InvalidArgumentsCount {
             expected_min: 1,
             expected_max: 2
         },
@@ -344,7 +344,7 @@ fn test_function() {
 
     assert_err!(
         FunctionCallExpr::lex_with("echo ( http.host, 10, \"test\" );", &SCHEME),
-        LexErrorKind::IncompatibleNumberArguments {
+        LexErrorKind::InvalidArgumentsCount {
             expected_min: 1,
             expected_max: 2,
         },

--- a/engine/src/functions.rs
+++ b/engine/src/functions.rs
@@ -46,7 +46,7 @@ pub enum FunctionArgKind {
 
 /// Defines a mandatory function argument.
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct FunctionArg {
+pub struct FunctionParam {
     /// How the argument can be specified when calling a function.
     pub arg_kind: FunctionArgKind,
     /// The type of its associated value.
@@ -55,7 +55,7 @@ pub struct FunctionArg {
 
 /// Defines an optional function argument.
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct FunctionOptArg {
+pub struct FunctionOptParam {
     /// How the argument can be specified when calling a function.
     pub arg_kind: FunctionArgKind,
     /// The default value if the argument is missing.
@@ -66,9 +66,9 @@ pub struct FunctionOptArg {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Function {
     /// List of mandatory arguments.
-    pub args: Vec<FunctionArg>,
+    pub params: Vec<FunctionParam>,
     /// List of optional arguments that can be specified after manatory ones.
-    pub opt_args: Vec<FunctionOptArg>,
+    pub opt_params: Vec<FunctionOptParam>,
     /// Function return type.
     pub return_type: Type,
     /// Actual implementation that will be called at runtime.

--- a/engine/src/lex.rs
+++ b/engine/src/lex.rs
@@ -54,8 +54,8 @@ pub enum LexErrorKind {
     #[fail(display = "unrecognised input")]
     EOF,
 
-    #[fail(display = "incompatible number of arguments")]
-    IncompatibleNumberArguments {
+    #[fail(display = "invalid number of arguments")]
+    InvalidArgumentsCount {
         expected_min: usize,
         expected_max: usize,
     },

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -96,7 +96,7 @@ pub use self::{
     ast::FilterAst,
     execution_context::{ExecutionContext, FieldValueTypeMismatchError},
     filter::{Filter, SchemeMismatchError},
-    functions::{Function, FunctionArg, FunctionArgKind, FunctionImpl, FunctionOptArg},
+    functions::{Function, FunctionArgKind, FunctionImpl, FunctionOptParam, FunctionParam},
     scheme::{FieldRedefinitionError, ParseError, Scheme, UnknownFieldError},
     types::{GetType, LhsValue, Type},
 };


### PR DESCRIPTION
This makes naming of these concepts more consistent with other languages, makes it easier to distinguish between the definition site and the call site, and frees up names like `FunctionArg` for other usages.