### PR TITLE
Implement TryFrom on LhsValue and unify type mismatch errors

### DIFF
--- a/engine/src/ast/function_expr.rs
+++ b/engine/src/ast/function_expr.rs
@@ -2,9 +2,9 @@ use super::field_expr::LhsFieldExpr;
 use crate::{
     execution_context::ExecutionContext,
     functions::{Function, FunctionArgKind, FunctionParam},
-    lex::{expect, skip_space, take, take_while, LexError, LexErrorKind, LexResult, LexWith},
+    lex::{expect, skip_space, span, take, take_while, LexError, LexErrorKind, LexResult, LexWith},
     scheme::{Field, Scheme},
-    types::{GetType, LhsValue, RhsValue},
+    types::{GetType, LhsValue, RhsValue, TypeMismatchError},
 };
 use serde::Serialize;
 
@@ -51,10 +51,12 @@ impl<'i, 's, 'a> LexWith<'i, SchemeFunctionParam<'s, 'a>> for FunctionCallArgExp
                     Err((
                         LexErrorKind::InvalidArgumentType {
                             index: ctx.index,
-                            given: lhs.get_type(),
-                            expected: ctx.param.val_type,
+                            mismatch: TypeMismatchError {
+                                actual: lhs.get_type(),
+                                expected: ctx.param.val_type,
+                            },
                         },
-                        initial_input,
+                        span(initial_input, input),
                     ))
                 } else {
                     Ok((FunctionCallArgExpr::LhsFieldExpr(lhs), input))
@@ -340,10 +342,12 @@ fn test_function() {
         FunctionCallExpr::lex_with("echo ( ip.addr );", &SCHEME),
         LexErrorKind::InvalidArgumentType {
             index: 0,
-            given: Type::Ip,
-            expected: Type::Bytes
+            mismatch: TypeMismatchError {
+                actual: Type::Ip,
+                expected: Type::Bytes,
+            }
         },
-        "ip.addr );"
+        "ip.addr"
     );
 
     assert_err!(

--- a/engine/src/lex.rs
+++ b/engine/src/lex.rs
@@ -1,7 +1,7 @@
 use crate::{
     rhs_types::RegexError,
     scheme::{UnknownFieldError, UnknownFunctionError},
-    types::Type,
+    types::{Type, TypeMismatchError},
 };
 use cidr::NetworkParseError;
 use failure::Fail;
@@ -62,11 +62,11 @@ pub enum LexErrorKind {
         expected_max: usize,
     },
 
-    #[fail(display = "invalid argument type")]
+    #[fail(display = "invalid type of argument #{}: {}", index, mismatch)]
     InvalidArgumentType {
         index: usize,
-        given: Type,
-        expected: Type,
+        #[cause]
+        mismatch: TypeMismatchError,
     },
 }
 

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -73,9 +73,9 @@ mod types;
 
 pub use self::{
     ast::FilterAst,
-    execution_context::{ExecutionContext, FieldValueTypeMismatchError},
+    execution_context::ExecutionContext,
     filter::{Filter, SchemeMismatchError},
     functions::{Function, FunctionArgKind, FunctionImpl, FunctionOptParam, FunctionParam},
     scheme::{FieldRedefinitionError, ParseError, Scheme, UnknownFieldError},
-    types::{GetType, LhsValue, Type},
+    types::{GetType, LhsValue, Type, TypeMismatchError},
 };


### PR DESCRIPTION
See commit messages for details.

In particular, this in combination with #14 should allow to more easily `.unwrap()` on owned arguments instead of handling type mismatches manually.