### PR TITLE
Introduce map data type

### DIFF
--- a/engine/benches/bench.rs
+++ b/engine/benches/bench.rs
@@ -82,7 +82,7 @@ impl<'a, T: 'static + Copy + Debug + Into<LhsValue<'static>>> FieldBench<'a, T> 
                 "parsing",
                 Benchmark::new(name, {
                     let mut scheme = Scheme::default();
-                    scheme.add_field(field.to_owned(), ty).unwrap();
+                    scheme.add_field(field.to_owned(), ty.clone()).unwrap();
                     for (name, function) in functions {
                         scheme
                             .add_function((*name).into(), function.clone())
@@ -98,7 +98,7 @@ impl<'a, T: 'static + Copy + Debug + Into<LhsValue<'static>>> FieldBench<'a, T> 
                 "compilation",
                 Benchmark::new(name, {
                     let mut scheme = Scheme::default();
-                    scheme.add_field(field.to_owned(), ty).unwrap();
+                    scheme.add_field(field.to_owned(), ty.clone()).unwrap();
                     for (name, function) in functions {
                         scheme
                             .add_function((*name).into(), function.clone())
@@ -118,7 +118,7 @@ impl<'a, T: 'static + Copy + Debug + Into<LhsValue<'static>>> FieldBench<'a, T> 
                     name,
                     {
                         let mut scheme = Scheme::default();
-                        scheme.add_field(field.to_owned(), ty).unwrap();
+                        scheme.add_field(field.to_owned(), ty.clone()).unwrap();
                         for (name, function) in functions {
                             scheme
                                 .add_function((*name).into(), function.clone())

--- a/engine/src/ast/combined_expr.rs
+++ b/engine/src/ast/combined_expr.rs
@@ -87,10 +87,10 @@ impl<'i, 's> LexWith<'i, &'s Scheme> for CombinedExpr<'s> {
 }
 
 impl<'s> Expr<'s> for CombinedExpr<'s> {
-    fn uses(&self, field: Field<'s>) -> bool {
+    fn uses(&self, field: &Field<'s>) -> bool {
         match self {
             CombinedExpr::Simple(op) => op.uses(field),
-            CombinedExpr::Combining { items, .. } => items.iter().any(|op| op.uses(field)),
+            CombinedExpr::Combining { items, .. } => items.iter().any(|op| op.uses(&field)),
         }
     }
 

--- a/engine/src/ast/field_expr.rs
+++ b/engine/src/ast/field_expr.rs
@@ -317,7 +317,7 @@ mod tests {
     };
     use cidr::{Cidr, IpCidr};
     use lazy_static::lazy_static;
-    use std::{collections::HashMap, net::IpAddr};
+    use std::net::IpAddr;
 
     fn echo_function<'a>(args: FunctionArgs<'_, 'a>) -> LhsValue<'a> {
         args.next().unwrap()
@@ -897,25 +897,20 @@ mod tests {
         let expr = expr.compile();
         let ctx = &mut ExecutionContext::new(&SCHEME);
 
-        let headers = LhsValue::Map(Map {
-            val_type: Type::Bytes,
-            data: {
-                let mut map = HashMap::new();
-                map.insert("host".to_string(), "example.org".into());
-                map
-            },
+        let headers = LhsValue::Map({
+            let mut map = Map::new(Type::Bytes);
+            map.insert("host".to_string(), "example.org".into())
+                .unwrap();
+            map
         });
 
         ctx.set_field_value("http.headers", headers).unwrap();
         assert_eq!(expr.execute(ctx), false);
 
-        let headers = LhsValue::Map(Map {
-            val_type: Type::Bytes,
-            data: {
-                let mut map = HashMap::new();
-                map.insert("host".to_string(), "abc.net.au".into());
-                map
-            },
+        let headers = LhsValue::Map({
+            let mut map = Map::new(Type::Bytes);
+            map.insert("host".to_string(), "abc.net.au".into()).unwrap();
+            map
         });
 
         ctx.set_field_value("http.headers", headers).unwrap();

--- a/engine/src/ast/field_expr.rs
+++ b/engine/src/ast/field_expr.rs
@@ -1,6 +1,8 @@
 // use crate::filter::CompiledExpr;
 use super::{function_expr::FunctionCallExpr, Expr};
 use crate::{
+    ast::index_expr::IndexExpr,
+    execution_context::ExecutionContext,
     filter::CompiledExpr,
     heap_searcher::HeapSearcher,
     lex::{skip_space, span, Lex, LexErrorKind, LexResult, LexWith},
@@ -139,17 +141,10 @@ impl<'s> LhsFieldExpr<'s> {
         }
     }
 
-    fn compile_with<F: 's>(self, func: F) -> CompiledExpr<'s>
-    where
-        F: Fn(LhsValue<'_>) -> bool,
-    {
+    pub fn execute(&'s self, ctx: &'s ExecutionContext<'s>) -> LhsValue<'s> {
         match self {
-            LhsFieldExpr::FunctionCallExpr(call) => {
-                CompiledExpr::new(move |ctx| func(call.execute(ctx)))
-            }
-            LhsFieldExpr::Field(f) => {
-                CompiledExpr::new(move |ctx| func(ctx.get_field_value_unchecked(&f)))
-            }
+            LhsFieldExpr::Field(f) => ctx.get_field_value_unchecked(&f),
+            LhsFieldExpr::FunctionCallExpr(call) => call.execute(ctx),
         }
     }
 }
@@ -178,7 +173,7 @@ impl<'s> GetType for LhsFieldExpr<'s> {
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize)]
 pub struct FieldExpr<'s> {
-    lhs: LhsFieldExpr<'s>,
+    lhs: IndexExpr<'s>,
 
     #[serde(flatten)]
     op: FieldOp,
@@ -188,7 +183,7 @@ impl<'i, 's> LexWith<'i, &'s Scheme> for FieldExpr<'s> {
     fn lex_with(input: &'i str, scheme: &'s Scheme) -> LexResult<'i, Self> {
         let initial_input = input;
 
-        let (lhs, input) = LhsFieldExpr::lex_with(input, scheme)?;
+        let (lhs, input) = IndexExpr::lex_with(input, scheme)?;
 
         let lhs_type = lhs.get_type();
 
@@ -317,10 +312,12 @@ mod tests {
             Function, FunctionArgKind, FunctionArgs, FunctionImpl, FunctionOptParam, FunctionParam,
         },
         rhs_types::IpRange,
+        scheme::FieldIndex,
+        types::Map,
     };
     use cidr::{Cidr, IpCidr};
     use lazy_static::lazy_static;
-    use std::net::IpAddr;
+    use std::{collections::HashMap, net::IpAddr};
 
     fn echo_function<'a>(args: FunctionArgs<'_, 'a>) -> LhsValue<'a> {
         args.next().unwrap()
@@ -357,6 +354,7 @@ mod tests {
                 ip.addr: Ip,
                 ssl: Bool,
                 tcp.port: Int,
+                http.headers: Map(Bytes),
             };
             scheme
                 .add_function(
@@ -419,7 +417,10 @@ mod tests {
         let expr = assert_ok!(
             FieldExpr::lex_with("ssl", &SCHEME),
             FieldExpr {
-                lhs: LhsFieldExpr::Field(field("ssl")),
+                lhs: IndexExpr {
+                    lhs: LhsFieldExpr::Field(field("ssl")),
+                    indexes: vec![],
+                },
                 op: FieldOp::IsTrue
             }
         );
@@ -447,7 +448,10 @@ mod tests {
         let expr = assert_ok!(
             FieldExpr::lex_with("ip.addr <= 10:20:30:40:50:60:70:80", &SCHEME),
             FieldExpr {
-                lhs: LhsFieldExpr::Field(field("ip.addr")),
+                lhs: IndexExpr {
+                    lhs: LhsFieldExpr::Field(field("ip.addr")),
+                    indexes: vec![],
+                },
                 op: FieldOp::Ordering {
                     op: OrderingOp::LessThanEqual,
                     rhs: RhsValue::Ip(IpAddr::from([
@@ -499,7 +503,10 @@ mod tests {
             let expr = assert_ok!(
                 FieldExpr::lex_with("http.host >= 10:20:30:40:50:60:70:80", &SCHEME),
                 FieldExpr {
-                    lhs: LhsFieldExpr::Field(field("http.host")),
+                    lhs: IndexExpr {
+                        lhs: LhsFieldExpr::Field(field("http.host")),
+                        indexes: vec![],
+                    },
                     op: FieldOp::Ordering {
                         op: OrderingOp::GreaterThanEqual,
                         rhs: RhsValue::Bytes(
@@ -524,7 +531,10 @@ mod tests {
             let expr = assert_ok!(
                 FieldExpr::lex_with(r#"http.host < 12"#, &SCHEME),
                 FieldExpr {
-                    lhs: LhsFieldExpr::Field(field("http.host")),
+                    lhs: IndexExpr {
+                        lhs: LhsFieldExpr::Field(field("http.host")),
+                        indexes: vec![],
+                    },
                     op: FieldOp::Ordering {
                         op: OrderingOp::LessThan,
                         rhs: RhsValue::Bytes(vec![0x12].into()),
@@ -545,7 +555,10 @@ mod tests {
         let expr = assert_ok!(
             FieldExpr::lex_with(r#"http.host == "example.org""#, &SCHEME),
             FieldExpr {
-                lhs: LhsFieldExpr::Field(field("http.host")),
+                lhs: IndexExpr {
+                    lhs: LhsFieldExpr::Field(field("http.host")),
+                    indexes: vec![],
+                },
                 op: FieldOp::Ordering {
                     op: OrderingOp::Equal,
                     rhs: RhsValue::Bytes("example.org".to_owned().into())
@@ -577,7 +590,10 @@ mod tests {
         let expr = assert_ok!(
             FieldExpr::lex_with("tcp.port & 1", &SCHEME),
             FieldExpr {
-                lhs: LhsFieldExpr::Field(field("tcp.port")),
+                lhs: IndexExpr {
+                    lhs: LhsFieldExpr::Field(field("tcp.port")),
+                    indexes: vec![],
+                },
                 op: FieldOp::Int {
                     op: IntOp::BitwiseAnd,
                     rhs: 1,
@@ -609,7 +625,10 @@ mod tests {
         let expr = assert_ok!(
             FieldExpr::lex_with(r#"tcp.port in { 80 443 2082..2083 }"#, &SCHEME),
             FieldExpr {
-                lhs: LhsFieldExpr::Field(field("tcp.port")),
+                lhs: IndexExpr {
+                    lhs: LhsFieldExpr::Field(field("tcp.port")),
+                    indexes: vec![],
+                },
                 op: FieldOp::OneOf(RhsValues::Int(vec![80..=80, 443..=443, 2082..=2083])),
             }
         );
@@ -657,7 +676,10 @@ mod tests {
         let expr = assert_ok!(
             FieldExpr::lex_with(r#"http.host in { "example.org" "example.com" }"#, &SCHEME),
             FieldExpr {
-                lhs: LhsFieldExpr::Field(field("http.host")),
+                lhs: IndexExpr {
+                    lhs: LhsFieldExpr::Field(field("http.host")),
+                    indexes: vec![],
+                },
                 op: FieldOp::OneOf(RhsValues::Bytes(
                     ["example.org", "example.com",]
                         .iter()
@@ -700,7 +722,10 @@ mod tests {
                 &SCHEME
             ),
             FieldExpr {
-                lhs: LhsFieldExpr::Field(field("ip.addr")),
+                lhs: IndexExpr {
+                    lhs: LhsFieldExpr::Field(field("ip.addr")),
+                    indexes: vec![],
+                },
                 op: FieldOp::OneOf(RhsValues::Ip(vec![
                     IpRange::Cidr(IpCidr::new([127, 0, 0, 0].into(), 8).unwrap()),
                     IpRange::Cidr(IpCidr::new_host([0, 0, 0, 0, 0, 0, 0, 1].into())),
@@ -753,7 +778,10 @@ mod tests {
         let expr = assert_ok!(
             FieldExpr::lex_with(r#"http.host contains "abc""#, &SCHEME),
             FieldExpr {
-                lhs: LhsFieldExpr::Field(field("http.host")),
+                lhs: IndexExpr {
+                    lhs: LhsFieldExpr::Field(field("http.host")),
+                    indexes: vec![],
+                },
                 op: FieldOp::Contains("abc".to_owned().into())
             }
         );
@@ -782,7 +810,10 @@ mod tests {
         let expr = assert_ok!(
             FieldExpr::lex_with(r#"http.host contains 6F:72:67"#, &SCHEME),
             FieldExpr {
-                lhs: LhsFieldExpr::Field(field("http.host")),
+                lhs: IndexExpr {
+                    lhs: LhsFieldExpr::Field(field("http.host")),
+                    indexes: vec![],
+                },
                 op: FieldOp::Contains(vec![0x6F, 0x72, 0x67].into()),
             }
         );
@@ -811,7 +842,10 @@ mod tests {
         let expr = assert_ok!(
             FieldExpr::lex_with(r#"tcp.port < 8000"#, &SCHEME),
             FieldExpr {
-                lhs: LhsFieldExpr::Field(field("tcp.port")),
+                lhs: IndexExpr {
+                    lhs: LhsFieldExpr::Field(field("tcp.port")),
+                    indexes: vec![],
+                },
                 op: FieldOp::Ordering {
                     op: OrderingOp::LessThan,
                     rhs: RhsValue::Int(8000)
@@ -839,17 +873,71 @@ mod tests {
     }
 
     #[test]
+    fn test_map_of_bytes_contains_str() {
+        let expr = assert_ok!(
+            FieldExpr::lex_with(r#"http.headers["host"] contains "abc""#, &SCHEME),
+            FieldExpr {
+                lhs: IndexExpr {
+                    lhs: LhsFieldExpr::Field(field("http.headers")),
+                    indexes: vec![FieldIndex::MapKey("host".to_string())],
+                },
+                op: FieldOp::Contains("abc".to_owned().into()),
+            }
+        );
+
+        assert_json!(
+            expr,
+            {
+                "lhs": ["http.headers", "host"],
+                "op": "Contains",
+                "rhs": "abc",
+            }
+        );
+
+        let expr = expr.compile();
+        let ctx = &mut ExecutionContext::new(&SCHEME);
+
+        let headers = LhsValue::Map(Map {
+            val_type: Type::Bytes,
+            data: {
+                let mut map = HashMap::new();
+                map.insert("host".to_string(), "example.org".into());
+                map
+            },
+        });
+
+        ctx.set_field_value("http.headers", headers).unwrap();
+        assert_eq!(expr.execute(ctx), false);
+
+        let headers = LhsValue::Map(Map {
+            val_type: Type::Bytes,
+            data: {
+                let mut map = HashMap::new();
+                map.insert("host".to_string(), "abc.net.au".into());
+                map
+            },
+        });
+
+        ctx.set_field_value("http.headers", headers).unwrap();
+        assert_eq!(expr.execute(ctx), true);
+    }
+
+    #[test]
     fn test_bytes_compare_with_echo_function() {
         let expr = assert_ok!(
             FieldExpr::lex_with(r#"echo(http.host) == "example.org""#, &SCHEME),
             FieldExpr {
-                lhs: LhsFieldExpr::FunctionCallExpr(FunctionCallExpr {
-                    name: String::from("echo"),
-                    function: SCHEME.get_function("echo").unwrap(),
-                    args: vec![FunctionCallArgExpr::LhsFieldExpr(LhsFieldExpr::Field(
-                        field("http.host")
-                    ))],
-                }),
+                lhs: IndexExpr {
+                    lhs: LhsFieldExpr::FunctionCallExpr(FunctionCallExpr {
+                        name: String::from("echo"),
+                        function: SCHEME.get_function("echo").unwrap(),
+                        args: vec![FunctionCallArgExpr::IndexExpr(IndexExpr {
+                            lhs: LhsFieldExpr::Field(field("http.host")),
+                            indexes: vec![],
+                        })],
+                    }),
+                    indexes: vec![],
+                },
                 op: FieldOp::Ordering {
                     op: OrderingOp::Equal,
                     rhs: RhsValue::Bytes("example.org".to_owned().into())
@@ -864,7 +952,7 @@ mod tests {
                     "name": "echo",
                     "args": [
                         {
-                            "kind": "LhsFieldExpr",
+                            "kind": "IndexExpr",
                             "value": "http.host"
                         }
                     ]
@@ -889,13 +977,17 @@ mod tests {
         let expr = assert_ok!(
             FieldExpr::lex_with(r#"lowercase(http.host) == "example.org""#, &SCHEME),
             FieldExpr {
-                lhs: LhsFieldExpr::FunctionCallExpr(FunctionCallExpr {
-                    name: String::from("lowercase"),
-                    function: SCHEME.get_function("lowercase").unwrap(),
-                    args: vec![FunctionCallArgExpr::LhsFieldExpr(LhsFieldExpr::Field(
-                        field("http.host")
-                    ))],
-                }),
+                lhs: IndexExpr {
+                    lhs: LhsFieldExpr::FunctionCallExpr(FunctionCallExpr {
+                        name: String::from("lowercase"),
+                        function: SCHEME.get_function("lowercase").unwrap(),
+                        args: vec![FunctionCallArgExpr::IndexExpr(IndexExpr {
+                            lhs: LhsFieldExpr::Field(field("http.host")),
+                            indexes: vec![],
+                        })],
+                    }),
+                    indexes: vec![],
+                },
                 op: FieldOp::Ordering {
                     op: OrderingOp::Equal,
                     rhs: RhsValue::Bytes("example.org".to_owned().into())
@@ -910,7 +1002,7 @@ mod tests {
                     "name": "lowercase",
                     "args": [
                         {
-                            "kind": "LhsFieldExpr",
+                            "kind": "IndexExpr",
                             "value": "http.host"
                         }
                     ]
@@ -935,13 +1027,17 @@ mod tests {
         let expr = assert_ok!(
             FieldExpr::lex_with(r#"concat(http.host) == "example.org""#, &SCHEME),
             FieldExpr {
-                lhs: LhsFieldExpr::FunctionCallExpr(FunctionCallExpr {
-                    name: String::from("concat"),
-                    function: SCHEME.get_function("concat").unwrap(),
-                    args: vec![FunctionCallArgExpr::LhsFieldExpr(LhsFieldExpr::Field(
-                        field("http.host")
-                    ))],
-                }),
+                lhs: IndexExpr {
+                    lhs: LhsFieldExpr::FunctionCallExpr(FunctionCallExpr {
+                        name: String::from("concat"),
+                        function: SCHEME.get_function("concat").unwrap(),
+                        args: vec![FunctionCallArgExpr::IndexExpr(IndexExpr {
+                            lhs: LhsFieldExpr::Field(field("http.host")),
+                            indexes: vec![],
+                        })],
+                    }),
+                    indexes: vec![],
+                },
                 op: FieldOp::Ordering {
                     op: OrderingOp::Equal,
                     rhs: RhsValue::Bytes("example.org".to_owned().into())
@@ -956,7 +1052,7 @@ mod tests {
                     "name": "concat",
                     "args": [
                         {
-                            "kind": "LhsFieldExpr",
+                            "kind": "IndexExpr",
                             "value": "http.host"
                         }
                     ]
@@ -978,16 +1074,22 @@ mod tests {
         let expr = assert_ok!(
             FieldExpr::lex_with(r#"concat(http.host, ".org") == "example.org""#, &SCHEME),
             FieldExpr {
-                lhs: LhsFieldExpr::FunctionCallExpr(FunctionCallExpr {
-                    name: String::from("concat"),
-                    function: SCHEME.get_function("concat").unwrap(),
-                    args: vec![
-                        FunctionCallArgExpr::LhsFieldExpr(LhsFieldExpr::Field(field("http.host"))),
-                        FunctionCallArgExpr::Literal(RhsValue::Bytes(Bytes::from(
-                            ".org".to_owned()
-                        ))),
-                    ],
-                }),
+                lhs: IndexExpr {
+                    lhs: LhsFieldExpr::FunctionCallExpr(FunctionCallExpr {
+                        name: String::from("concat"),
+                        function: SCHEME.get_function("concat").unwrap(),
+                        args: vec![
+                            FunctionCallArgExpr::IndexExpr(IndexExpr {
+                                lhs: LhsFieldExpr::Field(field("http.host")),
+                                indexes: vec![],
+                            }),
+                            FunctionCallArgExpr::Literal(RhsValue::Bytes(Bytes::from(
+                                ".org".to_owned()
+                            ))),
+                        ],
+                    }),
+                    indexes: vec![],
+                },
                 op: FieldOp::Ordering {
                     op: OrderingOp::Equal,
                     rhs: RhsValue::Bytes("example.org".to_owned().into())
@@ -1002,7 +1104,7 @@ mod tests {
                     "name": "concat",
                     "args": [
                         {
-                            "kind": "LhsFieldExpr",
+                            "kind": "IndexExpr",
                             "value": "http.host"
                         },
                         {

--- a/engine/src/ast/function_expr.rs
+++ b/engine/src/ast/function_expr.rs
@@ -1,5 +1,5 @@
-use super::field_expr::LhsFieldExpr;
 use crate::{
+    ast::index_expr::IndexExpr,
     execution_context::ExecutionContext,
     functions::{Function, FunctionArgKind, FunctionParam},
     lex::{expect, skip_space, span, take, take_while, LexError, LexErrorKind, LexResult, LexWith},
@@ -11,24 +11,21 @@ use serde::Serialize;
 #[derive(Debug, PartialEq, Eq, Clone, Serialize)]
 #[serde(tag = "kind", content = "value")]
 pub(crate) enum FunctionCallArgExpr<'s> {
-    LhsFieldExpr(LhsFieldExpr<'s>),
+    IndexExpr(IndexExpr<'s>),
     Literal(RhsValue),
 }
 
 impl<'s> FunctionCallArgExpr<'s> {
     pub fn uses(&self, field: &Field<'s>) -> bool {
         match self {
-            FunctionCallArgExpr::LhsFieldExpr(lhs) => lhs.uses(field),
+            FunctionCallArgExpr::IndexExpr(index_expr) => index_expr.uses(field),
             FunctionCallArgExpr::Literal(_) => false,
         }
     }
 
     pub fn execute(&'s self, ctx: &'s ExecutionContext<'s>) -> LhsValue<'s> {
         match self {
-            FunctionCallArgExpr::LhsFieldExpr(lhs) => match lhs {
-                LhsFieldExpr::Field(field) => ctx.get_field_value_unchecked(field),
-                LhsFieldExpr::FunctionCallExpr(call) => call.execute(ctx),
-            },
+            FunctionCallArgExpr::IndexExpr(index_expr) => index_expr.execute(ctx),
             FunctionCallArgExpr::Literal(literal) => literal.into(),
         }
     }
@@ -46,7 +43,7 @@ impl<'i, 's, 'a> LexWith<'i, SchemeFunctionParam<'s, 'a>> for FunctionCallArgExp
 
         match ctx.param.arg_kind {
             FunctionArgKind::Field => {
-                let (lhs, input) = LhsFieldExpr::lex_with(input, ctx.scheme)?;
+                let (lhs, input) = IndexExpr::lex_with(input, ctx.scheme)?;
                 if lhs.get_type() != ctx.param.val_type {
                     Err((
                         LexErrorKind::InvalidArgumentType {
@@ -59,7 +56,7 @@ impl<'i, 's, 'a> LexWith<'i, SchemeFunctionParam<'s, 'a>> for FunctionCallArgExp
                         span(initial_input, input),
                     ))
                 } else {
-                    Ok((FunctionCallArgExpr::LhsFieldExpr(lhs), input))
+                    Ok((FunctionCallArgExpr::IndexExpr(lhs), input))
                 }
             }
             FunctionArgKind::Literal => {
@@ -210,6 +207,7 @@ impl<'i, 's> LexWith<'i, &'s Scheme> for FunctionCallExpr<'s> {
 
 #[test]
 fn test_function() {
+    use super::field_expr::LhsFieldExpr;
     use crate::{
         functions::{FunctionArgs, FunctionImpl, FunctionOptParam},
         scheme::UnknownFieldError,
@@ -255,9 +253,10 @@ fn test_function() {
         FunctionCallExpr {
             name: String::from("echo"),
             function: SCHEME.get_function("echo").unwrap(),
-            args: vec![FunctionCallArgExpr::LhsFieldExpr(LhsFieldExpr::Field(
-                SCHEME.get_field_index("http.host").unwrap()
-            ))],
+            args: vec![FunctionCallArgExpr::IndexExpr(IndexExpr {
+                lhs: LhsFieldExpr::Field(SCHEME.get_field_index("http.host").unwrap()),
+                indexes: vec![],
+            })],
         },
         ";"
     );
@@ -268,7 +267,7 @@ fn test_function() {
             "name": "echo",
             "args": [
                 {
-                    "kind": "LhsFieldExpr",
+                    "kind": "IndexExpr",
                     "value": "http.host"
                 }
             ]
@@ -295,15 +294,17 @@ fn test_function() {
         FunctionCallExpr {
             name: String::from("echo"),
             function: SCHEME.get_function("echo").unwrap(),
-            args: [FunctionCallArgExpr::LhsFieldExpr(
-                LhsFieldExpr::FunctionCallExpr(FunctionCallExpr {
+            args: [FunctionCallArgExpr::IndexExpr(IndexExpr {
+                lhs: LhsFieldExpr::FunctionCallExpr(FunctionCallExpr {
                     name: String::from("echo"),
                     function: SCHEME.get_function("echo").unwrap(),
-                    args: vec![FunctionCallArgExpr::LhsFieldExpr(LhsFieldExpr::Field(
-                        SCHEME.get_field_index("http.host").unwrap()
-                    ))],
-                })
-            )]
+                    args: vec![FunctionCallArgExpr::IndexExpr(IndexExpr {
+                        lhs: LhsFieldExpr::Field(SCHEME.get_field_index("http.host").unwrap()),
+                        indexes: vec![],
+                    })],
+                }),
+                indexes: vec![],
+            })]
             .to_vec(),
         },
         ";"
@@ -315,12 +316,12 @@ fn test_function() {
             "name": "echo",
             "args": [
                 {
-                    "kind": "LhsFieldExpr",
+                    "kind": "IndexExpr",
                     "value": {
                         "name": "echo",
                         "args": [
                             {
-                                "kind": "LhsFieldExpr",
+                                "kind": "IndexExpr",
                                 "value": "http.host"
                             }
                         ]

--- a/engine/src/ast/function_expr.rs
+++ b/engine/src/ast/function_expr.rs
@@ -16,7 +16,7 @@ pub(crate) enum FunctionCallArgExpr<'s> {
 }
 
 impl<'s> FunctionCallArgExpr<'s> {
-    pub fn uses(&self, field: Field<'s>) -> bool {
+    pub fn uses(&self, field: &Field<'s>) -> bool {
         match self {
             FunctionCallArgExpr::LhsFieldExpr(lhs) => lhs.uses(field),
             FunctionCallArgExpr::Literal(_) => false,
@@ -26,7 +26,7 @@ impl<'s> FunctionCallArgExpr<'s> {
     pub fn execute(&'s self, ctx: &'s ExecutionContext<'s>) -> LhsValue<'s> {
         match self {
             FunctionCallArgExpr::LhsFieldExpr(lhs) => match lhs {
-                LhsFieldExpr::Field(field) => ctx.get_field_value_unchecked(*field),
+                LhsFieldExpr::Field(field) => ctx.get_field_value_unchecked(field),
                 LhsFieldExpr::FunctionCallExpr(call) => call.execute(ctx),
             },
             FunctionCallArgExpr::Literal(literal) => literal.into(),
@@ -53,7 +53,7 @@ impl<'i, 's, 'a> LexWith<'i, SchemeFunctionParam<'s, 'a>> for FunctionCallArgExp
                             index: ctx.index,
                             mismatch: TypeMismatchError {
                                 actual: lhs.get_type(),
-                                expected: ctx.param.val_type,
+                                expected: ctx.param.val_type.clone(),
                             },
                         },
                         span(initial_input, input),
@@ -63,7 +63,7 @@ impl<'i, 's, 'a> LexWith<'i, SchemeFunctionParam<'s, 'a>> for FunctionCallArgExp
                 }
             }
             FunctionArgKind::Literal => {
-                let (rhs_value, input) = RhsValue::lex_with(input, ctx.param.val_type)?;
+                let (rhs_value, input) = RhsValue::lex_with(input, ctx.param.val_type.clone())?;
                 Ok((FunctionCallArgExpr::Literal(rhs_value), input))
             }
         }
@@ -87,7 +87,7 @@ impl<'s> FunctionCallExpr<'s> {
         }
     }
 
-    pub fn uses(&self, field: Field<'s>) -> bool {
+    pub fn uses(&self, field: &Field<'s>) -> bool {
         self.args.iter().any(|arg| arg.uses(field))
     }
 

--- a/engine/src/ast/index_expr.rs
+++ b/engine/src/ast/index_expr.rs
@@ -1,0 +1,147 @@
+use super::field_expr::LhsFieldExpr;
+use crate::{
+    execution_context::ExecutionContext,
+    filter::CompiledExpr,
+    lex::{expect, skip_space, span, LexErrorKind, LexResult, LexWith},
+    scheme::{Field, FieldIndex, IndexAccessError, Scheme},
+    types::{GetType, LhsValue, RhsValue, Type},
+};
+use serde::{ser::SerializeSeq, Serialize, Serializer};
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+// IndexExpr is an expr that destructures an index into an LhsFieldExpr.
+//
+// For example, given a scheme which declares a field, http.request.headers,
+// as a map of string to list of strings, then the expression
+// http.request.headers["Cookie"][0] would have an LhsFieldExpr
+// http.request.headers and indexes ["Cookie", 0].
+pub(crate) struct IndexExpr<'s> {
+    pub lhs: LhsFieldExpr<'s>,
+    pub indexes: Vec<FieldIndex>,
+}
+
+impl<'s> IndexExpr<'s> {
+    pub fn uses(&self, field: &Field<'s>) -> bool {
+        self.lhs.uses(field)
+    }
+
+    pub fn compile_with<F: 's>(self, func: F) -> CompiledExpr<'s>
+    where
+        F: Fn(LhsValue<'_>) -> bool,
+    {
+        let Self { lhs, indexes } = self;
+        match lhs {
+            LhsFieldExpr::FunctionCallExpr(call) => CompiledExpr::new(move |ctx| {
+                func(
+                    indexes
+                        .iter()
+                        .fold(&call.execute(ctx), |value, idx| {
+                            value.get(idx).unwrap().unwrap()
+                        })
+                        .as_ref(),
+                )
+            }),
+            LhsFieldExpr::Field(f) => CompiledExpr::new(move |ctx| {
+                func(
+                    indexes
+                        .iter()
+                        .fold(&ctx.get_field_value_unchecked(&f), |value, idx| {
+                            value.get(idx).unwrap().unwrap()
+                        })
+                        .as_ref(),
+                )
+            }),
+        }
+    }
+
+    pub fn execute(&'s self, ctx: &'s ExecutionContext<'s>) -> LhsValue<'_> {
+        let value = self.lhs.execute(ctx);
+        if self.indexes.is_empty() {
+            value
+        } else {
+            self.indexes
+                .iter()
+                .fold(&value, |value, index| value.get(index).unwrap().unwrap())
+                .to_owned()
+        }
+    }
+}
+
+impl<'i, 's> LexWith<'i, &'s Scheme> for IndexExpr<'s> {
+    fn lex_with(mut input: &'i str, scheme: &'s Scheme) -> LexResult<'i, Self> {
+        let (lhs, rest) = LhsFieldExpr::lex_with(input, scheme)?;
+
+        let mut current_type = lhs.get_type();
+
+        let mut indexes = Vec::new();
+
+        input = rest;
+
+        while let Ok(rest) = expect(input, "[") {
+            let rest = skip_space(rest);
+
+            let (key, rest) = RhsValue::lex_with(rest, Type::Bytes)?;
+
+            let mut rest = skip_space(rest);
+
+            rest = expect(rest, "]")?;
+
+            match key {
+                RhsValue::Bytes(bytes) => {
+                    let index = FieldIndex::MapKey(String::from_utf8(bytes.to_vec()).unwrap());
+                    match current_type {
+                        Type::Map(map_type) => {
+                            current_type = *map_type;
+                            indexes.push(index);
+                        }
+                        _ => {
+                            return Err((
+                                LexErrorKind::InvalidIndexAccess(IndexAccessError {
+                                    index,
+                                    actual: current_type,
+                                }),
+                                span(input, rest),
+                            ))
+                        }
+                    }
+                }
+                _ => unreachable!(),
+            };
+
+            input = rest;
+        }
+
+        Ok((IndexExpr { lhs, indexes }, input))
+    }
+}
+
+impl<'s> GetType for IndexExpr<'s> {
+    fn get_type(&self) -> Type {
+        let mut ty = self.lhs.get_type();
+        for index in &self.indexes {
+            ty = match (ty, index) {
+                (Type::Map(child), FieldIndex::MapKey(_)) => (*child),
+                (_, _) => unreachable!(),
+            }
+        }
+        ty.clone()
+    }
+}
+
+impl<'s> Serialize for IndexExpr<'s> {
+    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        if self.indexes.is_empty() {
+            self.lhs.serialize(ser)
+        } else {
+            let mut seq = ser.serialize_seq(Some(self.indexes.len() + 1))?;
+            match &self.lhs {
+                LhsFieldExpr::Field(field) => seq.serialize_element(field)?,
+                LhsFieldExpr::FunctionCallExpr(call) => seq.serialize_element(call)?,
+            };
+            for index in &self.indexes {
+                seq.serialize_element(index)?;
+            }
+            seq.end()
+        }
+    }
+}

--- a/engine/src/ast/mod.rs
+++ b/engine/src/ast/mod.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 use std::fmt::{self, Debug};
 
 trait Expr<'s>: Sized + Eq + Debug + for<'i> LexWith<'i, &'s Scheme> + Serialize {
-    fn uses(&self, field: Field<'s>) -> bool;
+    fn uses(&self, field: &Field<'s>) -> bool;
     fn compile(self) -> CompiledExpr<'s>;
 }
 
@@ -51,7 +51,7 @@ impl<'s> FilterAst<'s> {
     pub fn uses(&self, field_name: &str) -> Result<bool, UnknownFieldError> {
         self.scheme
             .get_field_index(field_name)
-            .map(|field| self.op.uses(field))
+            .map(|field| self.op.uses(&field))
     }
 
     /// Compiles a [`FilterAst`] into a [`Filter`].

--- a/engine/src/ast/mod.rs
+++ b/engine/src/ast/mod.rs
@@ -1,6 +1,7 @@
 mod combined_expr;
 mod field_expr;
 mod function_expr;
+mod index_expr;
 mod simple_expr;
 
 use self::combined_expr::CombinedExpr;

--- a/engine/src/ast/simple_expr.rs
+++ b/engine/src/ast/simple_expr.rs
@@ -46,7 +46,7 @@ impl<'i, 's> LexWith<'i, &'s Scheme> for SimpleExpr<'s> {
 }
 
 impl<'s> Expr<'s> for SimpleExpr<'s> {
-    fn uses(&self, field: Field<'s>) -> bool {
+    fn uses(&self, field: &Field<'s>) -> bool {
         match self {
             SimpleExpr::Field(op) => op.uses(field),
             SimpleExpr::Parenthesized(op) => op.uses(field),

--- a/engine/src/execution_context.rs
+++ b/engine/src/execution_context.rs
@@ -29,7 +29,7 @@ impl<'e> ExecutionContext<'e> {
         self.scheme
     }
 
-    pub(crate) fn get_field_value_unchecked(&'e self, field: Field<'e>) -> LhsValue<'e> {
+    pub(crate) fn get_field_value_unchecked(&'e self, field: &Field<'e>) -> LhsValue<'e> {
         // This is safe because this code is reachable only from Filter::execute
         // which already performs the scheme compatibility check, but check that
         // invariant holds in the future at least in the debug mode.

--- a/engine/src/lex.rs
+++ b/engine/src/lex.rs
@@ -1,6 +1,6 @@
 use crate::{
     rhs_types::RegexError,
-    scheme::{UnknownFieldError, UnknownFunctionError},
+    scheme::{IndexAccessError, UnknownFieldError, UnknownFunctionError},
     types::{Type, TypeMismatchError},
 };
 use cidr::NetworkParseError;
@@ -68,6 +68,9 @@ pub enum LexErrorKind {
         #[cause]
         mismatch: TypeMismatchError,
     },
+
+    #[fail(display = "{}", _0)]
+    InvalidIndexAccess(#[cause] IndexAccessError),
 }
 
 pub type LexError<'i> = (LexErrorKind, &'i str);

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -78,6 +78,6 @@ pub use self::{
     functions::{
         Function, FunctionArgKind, FunctionArgs, FunctionImpl, FunctionOptParam, FunctionParam,
     },
-    scheme::{FieldRedefinitionError, ParseError, Scheme, UnknownFieldError},
-    types::{GetType, LhsValue, Type, TypeMismatchError},
+    scheme::{FieldIndex, FieldRedefinitionError, ParseError, Scheme, UnknownFieldError},
+    types::{GetType, LhsValue, Map, Type, TypeMismatchError},
 };

--- a/engine/src/rhs_types/map.rs
+++ b/engine/src/rhs_types/map.rs
@@ -1,0 +1,50 @@
+use crate::{
+    lex::{Lex, LexResult},
+    strict_partial_ord::StrictPartialOrd,
+    types::{GetType, Map, Type},
+};
+use serde::Serialize;
+use std::{borrow::Borrow, cmp::Ordering};
+
+/// [Uninhabited / empty type](https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types)
+/// for `map` with traits we need for RHS values.
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize)]
+pub enum UninhabitedMap {}
+
+impl<'a> Borrow<Map<'a>> for UninhabitedMap {
+    fn borrow(&self) -> &Map<'a> {
+        match *self {}
+    }
+}
+
+impl<'a> PartialEq<UninhabitedMap> for Map<'a> {
+    fn eq(&self, other: &UninhabitedMap) -> bool {
+        match *other {}
+    }
+}
+
+impl<'a> PartialOrd<UninhabitedMap> for Map<'a> {
+    fn partial_cmp(&self, other: &UninhabitedMap) -> Option<Ordering> {
+        match *other {}
+    }
+}
+
+impl<'a> StrictPartialOrd<UninhabitedMap> for Map<'a> {}
+
+impl<'i> Lex<'i> for UninhabitedMap {
+    fn lex(_input: &str) -> LexResult<'_, Self> {
+        unreachable!()
+    }
+}
+
+impl GetType for UninhabitedMap {
+    fn get_type(&self) -> Type {
+        unreachable!()
+    }
+}
+
+impl GetType for Vec<UninhabitedMap> {
+    fn get_type(&self) -> Type {
+        unreachable!()
+    }
+}

--- a/engine/src/rhs_types/mod.rs
+++ b/engine/src/rhs_types/mod.rs
@@ -2,11 +2,13 @@ mod bool;
 mod bytes;
 mod int;
 mod ip;
+mod map;
 mod regex;
 
 pub use self::{
     bool::UninhabitedBool,
     bytes::Bytes,
     ip::{ExplicitIpRange, IpRange},
+    map::UninhabitedMap,
     regex::{Error as RegexError, Regex},
 };

--- a/engine/src/scheme.rs
+++ b/engine/src/scheme.rs
@@ -12,10 +12,16 @@ use std::{
     cmp::{max, min},
     error::Error,
     fmt::{self, Debug, Display, Formatter},
+    iter::Iterator,
     ptr,
 };
 
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone)]
+pub enum FieldPathItem {
+    Name(String),
+}
+
+#[derive(PartialEq, Eq, Clone)]
 pub(crate) struct Field<'s> {
     scheme: &'s Scheme,
     index: usize,
@@ -75,7 +81,7 @@ impl<'s> Field<'s> {
 
 impl<'s> GetType for Field<'s> {
     fn get_type(&self) -> Type {
-        *self.scheme.fields.get_index(self.index).unwrap().1
+        self.scheme.fields.get_index(self.index).unwrap().1.clone()
     }
 }
 
@@ -313,11 +319,11 @@ macro_rules! Scheme {
             [$(
                 (
                     concat!(stringify!($ns) $(, ".", stringify!($field))*),
-                    $crate::Type::$ty
+                    $crate::Type::$ty,
                 )
             ),*]
             .iter()
-            .map(|&(k, v)| (k.to_owned(), v)),
+            .map(|&(k, ref v)| (k.to_owned(), v.clone())),
         )
         // Treat duplciations in static schemes as a developer's mistake.
         .unwrap_or_else(|err| panic!("{}", err))

--- a/engine/src/scheme.rs
+++ b/engine/src/scheme.rs
@@ -18,7 +18,9 @@ use std::{
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize)]
 #[serde(untagged)]
+/// Enum that describes a kind of index access operation
 pub enum FieldIndex {
+    /// Access the value associated with the key `MapKey` from a Map
     MapKey(String),
 }
 

--- a/engine/src/types.rs
+++ b/engine/src/types.rs
@@ -199,12 +199,38 @@ macro_rules! declare_types {
 /// A map of string to [`Type`].
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct Map<'a> {
-    pub val_type: Type,
+    val_type: Type,
     #[serde(borrow)]
-    pub data: HashMap<String, LhsValue<'a>>,
+    data: HashMap<String, LhsValue<'a>>,
 }
 
 impl<'a> Map<'a> {
+    pub fn new(val_type: Type) -> Self {
+        Self {
+            val_type,
+            data: HashMap::new(),
+        }
+    }
+
+    pub fn get(&self, key: &str) -> Option<&LhsValue<'a>> {
+        self.data.get(key)
+    }
+
+    pub fn insert(
+        &mut self,
+        key: String,
+        value: LhsValue<'a>,
+    ) -> Result<Option<LhsValue<'a>>, TypeMismatchError> {
+        let value_type = value.get_type();
+        if self.val_type != value_type {
+            return Err(TypeMismatchError {
+                expected: self.val_type.clone(),
+                actual: value_type,
+            });
+        }
+        Ok(self.data.insert(key, value))
+    }
+
     pub fn to_owned<'b>(&self) -> Map<'b> {
         let mut map = Map {
             val_type: self.val_type.clone(),

--- a/engine/src/types.rs
+++ b/engine/src/types.rs
@@ -1,6 +1,7 @@
 use crate::{
     lex::{expect, skip_space, Lex, LexResult, LexWith},
-    rhs_types::{Bytes, IpRange, UninhabitedBool},
+    rhs_types::{Bytes, IpRange, UninhabitedBool, UninhabitedMap},
+    scheme::FieldPathItem,
     strict_partial_ord::StrictPartialOrd,
 };
 use failure::Fail;
@@ -8,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
     cmp::Ordering,
-    convert::TryFrom,
+    collections::HashMap,
     fmt::{self, Debug, Formatter},
     net::IpAddr,
     ops::RangeInclusive,
@@ -43,6 +44,20 @@ pub struct TypeMismatchError {
     pub actual: Type,
 }
 
+macro_rules! replace_underscore {
+    ($name:ident ($val_ty:ty)) => {Type::$name(_)};
+    ($name:ident) => {Type::$name};
+}
+
+macro_rules! specialized_get_type {
+    (Map, $value:ident) => {
+        Type::Map(Box::new($value.get_type()))
+    };
+    ($name:ident, $value:ident) => {
+        Type::$name
+    };
+}
+
 macro_rules! declare_types {
     ($(# $attrs:tt)* enum $name:ident $(<$lt:tt>)* { $($(# $vattrs:tt)* $variant:ident ( $ty:ty ) , )* }) => {
         $(# $attrs)*
@@ -54,7 +69,7 @@ macro_rules! declare_types {
         impl $(<$lt>)* GetType for $name $(<$lt>)* {
             fn get_type(&self) -> Type {
                 match self {
-                    $($name::$variant(_) => Type::$variant,)*
+                    $($name::$variant(_value) => specialized_get_type!($variant, _value),)*
                 }
             }
         }
@@ -68,12 +83,22 @@ macro_rules! declare_types {
         }
     };
 
-    ($($(# $attrs:tt)* $name:ident ( $(# $lhs_attrs:tt)* $lhs_ty:ty | $rhs_ty:ty | $multi_rhs_ty:ty ) , )*) => {
+    ($($(# $attrs:tt)* $name:ident $([$val_ty:ty])? ( $(# $lhs_attrs:tt)* $lhs_ty:ty | $rhs_ty:ty | $multi_rhs_ty:ty ) , )*) => {
         /// Enumeration of supported types for field values.
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+        #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
         #[repr(C)]
         pub enum Type {
-            $($(# $attrs)* $name,)*
+            $($(# $attrs)* $name$(($val_ty))?,)*
+        }
+
+        impl Type {
+            /// Returns the inner type when available (e.g: for a Map)
+            pub fn next(&self) -> Option<Type> {
+                match self {
+                    Type::Map(ty) => Some(*ty.clone()),
+                    _ => None,
+                }
+            }
         }
 
         /// Provides a way to get a [`Type`] of the implementor.
@@ -84,7 +109,7 @@ macro_rules! declare_types {
 
         impl GetType for Type {
             fn get_type(&self) -> Type {
-                *self
+                self.clone()
             }
         }
 
@@ -107,20 +132,6 @@ macro_rules! declare_types {
             }
         })*
 
-        $(impl<'a> TryFrom<LhsValue<'a>> for $lhs_ty {
-            type Error = TypeMismatchError;
-
-            fn try_from(value: LhsValue<'a>) -> Result<$lhs_ty, TypeMismatchError> {
-                match value {
-                    LhsValue::$name(value) => Ok(value),
-                    _ => Err(TypeMismatchError {
-                        expected: Type::$name,
-                        actual: value.get_type(),
-                    }),
-                }
-            }
-        })*
-
         declare_types! {
             /// An RHS value parsed from a filter string.
             #[derive(PartialEq, Eq, Clone, Serialize)]
@@ -133,7 +144,7 @@ macro_rules! declare_types {
         impl<'i> LexWith<'i, Type> for RhsValue {
             fn lex_with(input: &str, ty: Type) -> LexResult<'_, Self> {
                 Ok(match ty {
-                    $(Type::$name => {
+                    $(replace_underscore!($name $(($val_ty))?) => {
                         let (value, input) = <$rhs_ty>::lex(input)?;
                         (RhsValue::$name(value), input)
                     })*
@@ -175,7 +186,7 @@ macro_rules! declare_types {
         impl<'i> LexWith<'i, Type> for RhsValues {
             fn lex_with(input: &str, ty: Type) -> LexResult<'_, Self> {
                 Ok(match ty {
-                    $(Type::$name => {
+                    $(replace_underscore!($name $(($val_ty))?) => {
                         let (value, input) = lex_rhs_values(input)?;
                         (RhsValues::$name(value), input)
                     })*
@@ -183,6 +194,20 @@ macro_rules! declare_types {
             }
         }
     };
+}
+
+/// A map of string to [`Type`].
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct Map<'a> {
+    pub val_type: Type,
+    #[serde(borrow)]
+    pub data: HashMap<String, LhsValue<'a>>,
+}
+
+impl<'a> GetType for Map<'a> {
+    fn get_type(&self) -> Type {
+        self.val_type.clone()
+    }
 }
 
 // special case for simply passing bytes
@@ -206,6 +231,7 @@ impl<'a> From<&'a RhsValue> for LhsValue<'a> {
             RhsValue::Bytes(bytes) => LhsValue::Bytes(Cow::Borrowed(bytes)),
             RhsValue::Int(integer) => LhsValue::Int(*integer),
             RhsValue::Bool(b) => match *b {},
+            RhsValue::Map(m) => match *m {},
         }
     }
 }
@@ -219,6 +245,25 @@ impl<'a> LhsValue<'a> {
             LhsValue::Bytes(bytes) => LhsValue::Bytes(Cow::Borrowed(bytes)),
             LhsValue::Int(integer) => LhsValue::Int(*integer),
             LhsValue::Bool(b) => LhsValue::Bool(*b),
+            LhsValue::Map(m) => LhsValue::Map(m.clone()),
+        }
+    }
+
+    /// Retrieve an element from an LhsValue given a path item and a specified
+    /// type.
+    /// Returns a TypeMismatchError error if current type does not support it
+    /// nested element. Only LhsValue::Map supports nested elements for now.
+    pub fn get(
+        &self,
+        item: &FieldPathItem,
+        ty: &Type,
+    ) -> Result<Option<&LhsValue>, TypeMismatchError> {
+        match (self, item) {
+            (LhsValue::Map(map), FieldPathItem::Name(ref name)) => Ok(map.data.get(name)),
+            (_, FieldPathItem::Name(_name)) => Err(TypeMismatchError {
+                expected: Type::Map(Box::new(ty.clone())),
+                actual: self.get_type(),
+            }),
         }
     }
 }
@@ -240,6 +285,9 @@ declare_types!(
 
     /// A boolean.
     Bool(bool | UninhabitedBool | UninhabitedBool),
+
+    /// A map of string to [`Type`].
+    Map[Box<Type>](Map<'a> | UninhabitedMap | UninhabitedMap),
 );
 
 #[test]

--- a/engine/src/types.rs
+++ b/engine/src/types.rs
@@ -1,7 +1,7 @@
 use crate::{
     lex::{expect, skip_space, Lex, LexResult, LexWith},
     rhs_types::{Bytes, IpRange, UninhabitedBool, UninhabitedMap},
-    scheme::FieldPathItem,
+    scheme::{FieldIndex, IndexAccessError},
     strict_partial_ord::StrictPartialOrd,
 };
 use failure::Fail;
@@ -204,6 +204,19 @@ pub struct Map<'a> {
     pub data: HashMap<String, LhsValue<'a>>,
 }
 
+impl<'a> Map<'a> {
+    pub fn to_owned<'b>(&self) -> Map<'b> {
+        let mut map = Map {
+            val_type: self.val_type.clone(),
+            data: Default::default(),
+        };
+        for (k, v) in self.data.iter() {
+            map.data.insert(k.clone(), v.to_owned());
+        }
+        map
+    }
+}
+
 impl<'a> GetType for Map<'a> {
     fn get_type(&self) -> Type {
         self.val_type.clone()
@@ -253,17 +266,29 @@ impl<'a> LhsValue<'a> {
     /// type.
     /// Returns a TypeMismatchError error if current type does not support it
     /// nested element. Only LhsValue::Map supports nested elements for now.
-    pub fn get(
-        &self,
-        item: &FieldPathItem,
-        ty: &Type,
-    ) -> Result<Option<&LhsValue>, TypeMismatchError> {
+    pub fn get(&'a self, item: &FieldIndex) -> Result<Option<&'a LhsValue<'a>>, IndexAccessError> {
         match (self, item) {
-            (LhsValue::Map(map), FieldPathItem::Name(ref name)) => Ok(map.data.get(name)),
-            (_, FieldPathItem::Name(_name)) => Err(TypeMismatchError {
-                expected: Type::Map(Box::new(ty.clone())),
+            (LhsValue::Map(map), FieldIndex::MapKey(ref name)) => Ok(map.data.get(name)),
+            (_, FieldIndex::MapKey(_name)) => Err(IndexAccessError {
+                index: item.clone(),
                 actual: self.get_type(),
             }),
+        }
+    }
+
+    /// Deep clone of an LhsValue.
+    /// Will convert any Cow::Borrowed to Cow::Owned and copy
+    /// already existing Cow::Owned.
+    pub fn to_owned<'b>(&self) -> LhsValue<'b> {
+        match &self {
+            LhsValue::Ip(ip) => LhsValue::Ip(*ip),
+            LhsValue::Bytes(bytes) => match bytes {
+                Cow::Borrowed(raw) => LhsValue::Bytes(Cow::Owned(raw.to_vec())),
+                Cow::Owned(raw) => LhsValue::Bytes(Cow::Owned(raw.to_vec())),
+            },
+            LhsValue::Int(integer) => LhsValue::Int(*integer),
+            LhsValue::Bool(b) => LhsValue::Bool(*b),
+            LhsValue::Map(m) => LhsValue::Map(m.to_owned()),
         }
     }
 }

--- a/ffi/include/wirefilter.h
+++ b/ffi/include/wirefilter.h
@@ -12,6 +12,7 @@ typedef struct wirefilter_scheme wirefilter_scheme_t;
 typedef struct wirefilter_execution_context wirefilter_execution_context_t;
 typedef struct wirefilter_filter_ast wirefilter_filter_ast_t;
 typedef struct wirefilter_filter wirefilter_filter_t;
+typedef struct wirefilter_map wirefilter_map_t;
 
 typedef struct {
     const char *data;
@@ -46,14 +47,27 @@ typedef union {
 } wirefilter_parsing_result_t;
 
 typedef enum {
-    WIREFILTER_TYPE_IP,
-    WIREFILTER_TYPE_BYTES,
-    WIREFILTER_TYPE_INT,
-    WIREFILTER_TYPE_BOOL,
+    WIREFILTER_TYPE_TAG_IP,
+    WIREFILTER_TYPE_TAG_BYTES,
+    WIREFILTER_TYPE_TAG_INT,
+    WIREFILTER_TYPE_TAG_BOOL,
+    WIREFILTER_TYPE_TAG_MAP,
+} wirefilter_type_tag_t;
+
+typedef struct {
+    wirefilter_type_tag_t tag;
+    void *data[2];
 } wirefilter_type_t;
+
+static const wirefilter_type_t WIREFILTER_TYPE_IP = {.tag = WIREFILTER_TYPE_TAG_IP, .data = {NULL, NULL}};
+static const wirefilter_type_t WIREFILTER_TYPE_BYTES = {.tag = WIREFILTER_TYPE_TAG_BYTES, .data = {NULL, NULL}};
+static const wirefilter_type_t WIREFILTER_TYPE_INT = {.tag = WIREFILTER_TYPE_TAG_INT, .data = {NULL, NULL}};
+static const wirefilter_type_t WIREFILTER_TYPE_BOOL = {.tag = WIREFILTER_TYPE_TAG_BOOL, .data = {NULL, NULL}};
 
 wirefilter_scheme_t *wirefilter_create_scheme();
 void wirefilter_free_scheme(wirefilter_scheme_t *scheme);
+
+wirefilter_type_t wirefilter_create_map_type(wirefilter_type_t type);
 
 void wirefilter_add_type_field_to_scheme(
     wirefilter_scheme_t *scheme,
@@ -107,6 +121,52 @@ void wirefilter_add_bool_value_to_execution_context(
     wirefilter_externally_allocated_str_t name,
     bool value
 );
+
+void wirefilter_add_map_value_to_execution_context(
+    wirefilter_execution_context_t *exec_ctx,
+    wirefilter_externally_allocated_str_t name,
+    wirefilter_map_t *map
+);
+
+wirefilter_map_t *wirefilter_create_map(wirefilter_type_t type);
+
+void wirefilter_add_int_value_to_map(
+    wirefilter_map_t *map,
+    wirefilter_externally_allocated_str_t name,
+    int32_t value
+);
+
+void wirefilter_add_bytes_value_to_map(
+    wirefilter_map_t *map,
+    wirefilter_externally_allocated_str_t name,
+    wirefilter_externally_allocated_byte_arr_t value
+);
+
+void wirefilter_add_ipv6_value_to_map(
+    wirefilter_map_t *map,
+    wirefilter_externally_allocated_str_t name,
+    uint8_t value[16]
+);
+
+void wirefilter_add_ipv4_value_to_map(
+    wirefilter_map_t *map,
+    wirefilter_externally_allocated_str_t name,
+    uint8_t value[4]
+);
+
+void wirefilter_add_bool_value_to_map(
+    wirefilter_map_t *map,
+    wirefilter_externally_allocated_str_t name,
+    bool value
+);
+
+void wirefilter_add_map_value_to_map(
+    wirefilter_map_t *map,
+    wirefilter_externally_allocated_str_t name,
+    wirefilter_map_t *value
+);
+
+void wirefilter_free_map(wirefilter_map_t *map);
 
 bool wirefilter_match(
     const wirefilter_filter_t *filter,

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -14,6 +14,14 @@ use wirefilter::{ExecutionContext, Filter, FilterAst, ParseError, Scheme, Type};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
+#[repr(C)]
+pub enum SimpleType {
+    Ip,
+    Bytes,
+    Int,
+    Bool,
+}
+
 #[repr(u8)]
 pub enum ParsingResult<'s> {
     Err(RustAllocatedString),
@@ -55,8 +63,14 @@ pub extern "C" fn wirefilter_free_scheme(scheme: RustBox<Scheme>) {
 pub extern "C" fn wirefilter_add_type_field_to_scheme(
     scheme: &mut Scheme,
     name: ExternallyAllocatedStr<'_>,
-    ty: Type,
+    ty: SimpleType,
 ) {
+    let ty = match ty {
+        SimpleType::Ip => Type::Ip,
+        SimpleType::Bytes => Type::Bytes,
+        SimpleType::Int => Type::Int,
+        SimpleType::Bool => Type::Bool,
+    };
     scheme.add_field(name.into_ref().to_owned(), ty).unwrap();
 }
 
@@ -244,34 +258,34 @@ mod ffi_test {
         wirefilter_add_type_field_to_scheme(
             &mut scheme,
             ExternallyAllocatedStr::from("ip1"),
-            Type::Ip,
+            SimpleType::Ip,
         );
         wirefilter_add_type_field_to_scheme(
             &mut scheme,
             ExternallyAllocatedStr::from("ip2"),
-            Type::Ip,
+            SimpleType::Ip,
         );
 
         wirefilter_add_type_field_to_scheme(
             &mut scheme,
             ExternallyAllocatedStr::from("str1"),
-            Type::Bytes,
+            SimpleType::Bytes,
         );
         wirefilter_add_type_field_to_scheme(
             &mut scheme,
             ExternallyAllocatedStr::from("str2"),
-            Type::Bytes,
+            SimpleType::Bytes,
         );
 
         wirefilter_add_type_field_to_scheme(
             &mut scheme,
             ExternallyAllocatedStr::from("num1"),
-            Type::Int,
+            SimpleType::Int,
         );
         wirefilter_add_type_field_to_scheme(
             &mut scheme,
             ExternallyAllocatedStr::from("num2"),
-            Type::Int,
+            SimpleType::Int,
         );
 
         scheme

--- a/ffi/src/transfer_types/ownership_repr/rust_box.rs
+++ b/ffi/src/transfer_types/ownership_repr/rust_box.rs
@@ -5,6 +5,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
+#[derive(Debug)]
 #[repr(transparent)]
 pub struct RustBox<T: ?Sized + ExternPtrRepr> {
     ptr: T::Repr,

--- a/ffi/tests/ctests/src/lib.rs
+++ b/ffi/tests/ctests/src/lib.rs
@@ -40,5 +40,6 @@ mod ffi_ctest {
         create_execution_context,
         add_values_to_execution_context,
         match_filter,
+        match_map,
     );
 }

--- a/ffi/tests/ctests/src/tests.c
+++ b/ffi/tests/ctests/src/tests.c
@@ -34,6 +34,11 @@ void initialize_scheme(wirefilter_scheme_t *scheme) {
         wirefilter_string("tcp.port"),
         WIREFILTER_TYPE_INT
     );
+    wirefilter_add_type_field_to_scheme(
+        scheme,
+        wirefilter_string("http.headers"),
+        wirefilter_create_map_type(WIREFILTER_TYPE_BYTES)
+    );
 }
 
 void wirefilter_ffi_ctest_create_scheme() {
@@ -299,6 +304,78 @@ void wirefilter_ffi_ctest_match_filter() {
         exec_ctx,
         wirefilter_string("tcp.port"),
         80
+    );
+
+    rust_assert(wirefilter_match(filter, exec_ctx) == true, "could not match filter");
+
+    wirefilter_free_execution_context(exec_ctx);
+
+    wirefilter_free_compiled_filter(filter);
+
+    wirefilter_free_scheme(scheme);
+}
+
+void wirefilter_ffi_ctest_match_map() {
+    wirefilter_scheme_t *scheme = wirefilter_create_scheme();
+    rust_assert(scheme != NULL, "could not create scheme");
+
+    initialize_scheme(scheme);
+
+    wirefilter_parsing_result_t result = wirefilter_parse_filter(
+        scheme,
+        wirefilter_string("http.headers[\"host\"] == \"www.cloudflare.com\"")
+    );
+    rust_assert(result.success == true, "could not parse good filter");
+    rust_assert(result.ok.ast != NULL, "could not parse good filter");
+
+    wirefilter_filter_t *filter = wirefilter_compile_filter(result.ok.ast);
+    rust_assert(filter != NULL, "could not compile filter");
+
+    wirefilter_execution_context_t *exec_ctx = wirefilter_create_execution_context(scheme);
+    rust_assert(exec_ctx != NULL, "could not create execution context");
+
+    wirefilter_externally_allocated_byte_arr_t http_host;
+    http_host.data = (unsigned char *)"www.cloudflare.com";
+    http_host.length = strlen((char *)http_host.data);
+    wirefilter_add_bytes_value_to_execution_context(
+        exec_ctx,
+        wirefilter_string("http.host"),
+        http_host
+    );
+
+    uint8_t ip_addr[4] = {192, 168, 0, 1};
+    wirefilter_add_ipv4_value_to_execution_context(
+        exec_ctx,
+        wirefilter_string("ip.addr"),
+        ip_addr
+    );
+
+    wirefilter_add_bool_value_to_execution_context(
+        exec_ctx,
+        wirefilter_string("ssl"),
+        false
+    );
+
+    wirefilter_add_int_value_to_execution_context(
+        exec_ctx,
+        wirefilter_string("tcp.port"),
+        80
+    );
+
+    wirefilter_map_t *http_headers = wirefilter_create_map(
+        WIREFILTER_TYPE_BYTES
+    );
+
+    wirefilter_add_bytes_value_to_map(
+        http_headers,
+        wirefilter_string("host"),
+        http_host
+    );
+
+    wirefilter_add_map_value_to_execution_context(
+        exec_ctx,
+        wirefilter_string("http.headers"),
+        http_headers
     );
 
     rust_assert(wirefilter_match(filter, exec_ctx) == true, "could not match filter");


### PR DESCRIPTION
This patch series introduce a new `Map` data type. It is useful to describe named data that are only known at execution time.

`Type` is not copy-able anymore because the new `Type::Map` variant holds `Box<Type>` to describe the type of values stored in the map. Keys are always expected to be regular strings.
A new `Map` structure has been defined that holds a `Type` and a `HashMap<LhsValue>`, type checking is done at filter parsing and data insertion time.
`FieldIndex` is an enum that describe how to access an element from an `LhsValue`. It currently only has one `MapKey` variant to access an element of a map but can be improved in the future to handle `ArrayIndex` when the array data type will be introduced.
On the syntax side, map element can be accessed using the classic [] operator: `a.map["key"]`.

This work revealed that it might be relevant to handle the case of missing value at execution of a properly defined field. Because the data stored in the map are inherently not reliably predicted, its not viable anymore to panic when a value is missing.
