### PR TITLE
Introduce the SchemeConfig structure as a way to configure the engine.

### DIFF
--- a/engine/src/ast/function_expr.rs
+++ b/engine/src/ast/function_expr.rs
@@ -32,6 +32,13 @@ impl<'s> FunctionCallArgExpr<'s> {
             FunctionCallArgExpr::Literal(literal) => literal.into(),
         }
     }
+
+    pub fn depth(&self) -> usize {
+        match self {
+            FunctionCallArgExpr::LhsFieldExpr(lhs) => lhs.depth(),
+            FunctionCallArgExpr::Literal(_) => 0,
+        }
+    }
 }
 
 struct SchemeFunctionParam<'s, 'a> {
@@ -99,6 +106,15 @@ impl<'s> FunctionCallExpr<'s> {
                     .map(|opt_arg| opt_arg.default_value.as_ref()),
             ),
         )
+    }
+
+    pub fn depth(&self) -> usize {
+        1 + self
+            .args
+            .iter()
+            .map(FunctionCallArgExpr::depth)
+            .max()
+            .unwrap_or(0)
     }
 }
 

--- a/engine/src/lex.rs
+++ b/engine/src/lex.rs
@@ -68,6 +68,12 @@ pub enum LexErrorKind {
         #[cause]
         mismatch: TypeMismatchError,
     },
+
+    #[fail(
+        display = "call stack depth should not exceed {} levels, but {} levels",
+        limit, actual
+    )]
+    CallStackTooDeep { limit: usize, actual: usize },
 }
 
 pub type LexError<'i> = (LexErrorKind, &'i str);

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -78,6 +78,6 @@ pub use self::{
     functions::{
         Function, FunctionArgKind, FunctionArgs, FunctionImpl, FunctionOptParam, FunctionParam,
     },
-    scheme::{FieldRedefinitionError, ParseError, Scheme, UnknownFieldError},
+    scheme::{FieldRedefinitionError, ParseError, Scheme, SchemeConfig, UnknownFieldError},
     types::{GetType, LhsValue, Type, TypeMismatchError},
 };


### PR DESCRIPTION
Only call_stack_depth_limit is declared at this time.