### PR TITLE
 Handle missing value from ExecutionContext

### DIFF
--- a/engine/benches/bench.rs
+++ b/engine/benches/bench.rs
@@ -14,8 +14,8 @@ use wirefilter::{
     FunctionParam, GetType, LhsValue, Scheme, Type,
 };
 
-fn lowercase<'a>(args: FunctionArgs<'_, 'a>) -> LhsValue<'a> {
-    let input = args.next().unwrap();
+fn lowercase<'a>(args: FunctionArgs<'_, 'a>) -> Option<LhsValue<'a>> {
+    let input = args.next()?.ok()?;
     match input {
         LhsValue::Bytes(mut bytes) => {
             let make_lowercase = match bytes {
@@ -25,14 +25,14 @@ fn lowercase<'a>(args: FunctionArgs<'_, 'a>) -> LhsValue<'a> {
             if make_lowercase {
                 bytes.to_mut().make_ascii_lowercase();
             }
-            LhsValue::Bytes(bytes)
+            Some(LhsValue::Bytes(bytes))
         }
         _ => panic!("Invalid type: expected Bytes, got {:?}", input),
     }
 }
 
-fn uppercase<'a>(args: FunctionArgs<'_, 'a>) -> LhsValue<'a> {
-    let input = args.next().unwrap();
+fn uppercase<'a>(args: FunctionArgs<'_, 'a>) -> Option<LhsValue<'a>> {
+    let input = args.next()?.ok()?;
     match input {
         LhsValue::Bytes(mut bytes) => {
             let make_uppercase = match bytes {
@@ -42,7 +42,7 @@ fn uppercase<'a>(args: FunctionArgs<'_, 'a>) -> LhsValue<'a> {
             if make_uppercase {
                 bytes.to_mut().make_ascii_uppercase();
             }
-            LhsValue::Bytes(bytes)
+            Some(LhsValue::Bytes(bytes))
         }
         _ => panic!("Invalid type: expected Bytes, got {:?}", input),
     }

--- a/engine/examples/cli.rs
+++ b/engine/examples/cli.rs
@@ -4,7 +4,7 @@ use wirefilter::{
     LhsValue, Scheme, Type,
 };
 
-fn panic_function<'a>(_: FunctionArgs<'_, 'a>) -> LhsValue<'a> {
+fn panic_function<'a>(_: FunctionArgs<'_, 'a>) -> Option<LhsValue<'a>> {
     panic!();
 }
 

--- a/engine/src/ast/field_expr.rs
+++ b/engine/src/ast/field_expr.rs
@@ -439,6 +439,8 @@ mod tests {
         let expr = expr.compile();
         let ctx = &mut ExecutionContext::new(&SCHEME);
 
+        assert_eq!(expr.execute(ctx), false);
+
         ctx.set_field_value("ssl", true).unwrap();
         assert_eq!(expr.execute(ctx), true);
 
@@ -472,6 +474,8 @@ mod tests {
 
         let expr = expr.compile();
         let ctx = &mut ExecutionContext::new(&SCHEME);
+
+        assert_eq!(expr.execute(ctx), false);
 
         ctx.set_field_value("ip.addr", IpAddr::from([0, 0, 0, 0, 0, 0, 0, 1]))
             .unwrap();
@@ -569,6 +573,8 @@ mod tests {
         let expr = expr.compile();
         let ctx = &mut ExecutionContext::new(&SCHEME);
 
+        assert_eq!(expr.execute(ctx), false);
+
         ctx.set_field_value("http.host", "example.com").unwrap();
         assert_eq!(expr.execute(ctx), false);
 
@@ -600,6 +606,8 @@ mod tests {
 
         let expr = expr.compile();
         let ctx = &mut ExecutionContext::new(&SCHEME);
+
+        assert_eq!(expr.execute(ctx), false);
 
         ctx.set_field_value("tcp.port", 80).unwrap();
         assert_eq!(expr.execute(ctx), false);
@@ -633,6 +641,8 @@ mod tests {
 
         let expr = expr.compile();
         let ctx = &mut ExecutionContext::new(&SCHEME);
+
+        assert_eq!(expr.execute(ctx), false);
 
         ctx.set_field_value("tcp.port", 80).unwrap();
         assert_eq!(expr.execute(ctx), true);
@@ -686,6 +696,8 @@ mod tests {
         let expr = expr.compile();
         let ctx = &mut ExecutionContext::new(&SCHEME);
 
+        assert_eq!(expr.execute(ctx), false);
+
         ctx.set_field_value("http.host", "example.com").unwrap();
         assert_eq!(expr.execute(ctx), true);
 
@@ -731,6 +743,8 @@ mod tests {
         let expr = expr.compile();
         let ctx = &mut ExecutionContext::new(&SCHEME);
 
+        assert_eq!(expr.execute(ctx), false);
+
         ctx.set_field_value("ip.addr", IpAddr::from([127, 0, 0, 1]))
             .unwrap();
         assert_eq!(expr.execute(ctx), true);
@@ -774,6 +788,8 @@ mod tests {
         let expr = expr.compile();
         let ctx = &mut ExecutionContext::new(&SCHEME);
 
+        assert_eq!(expr.execute(ctx), false);
+
         ctx.set_field_value("http.host", "example.org").unwrap();
         assert_eq!(expr.execute(ctx), false);
 
@@ -802,6 +818,8 @@ mod tests {
 
         let expr = expr.compile();
         let ctx = &mut ExecutionContext::new(&SCHEME);
+
+        assert_eq!(expr.execute(ctx), false);
 
         ctx.set_field_value("http.host", "example.com").unwrap();
         assert_eq!(expr.execute(ctx), false);
@@ -834,6 +852,8 @@ mod tests {
 
         let expr = expr.compile();
         let ctx = &mut ExecutionContext::new(&SCHEME);
+
+        assert_eq!(expr.execute(ctx), false);
 
         ctx.set_field_value("tcp.port", 80).unwrap();
         assert_eq!(expr.execute(ctx), true);
@@ -881,6 +901,8 @@ mod tests {
         let expr = expr.compile();
         let ctx = &mut ExecutionContext::new(&SCHEME);
 
+        assert_eq!(expr.execute(ctx), false);
+
         ctx.set_field_value("http.host", "example.com").unwrap();
         assert_eq!(expr.execute(ctx), false);
 
@@ -927,6 +949,8 @@ mod tests {
         let expr = expr.compile();
         let ctx = &mut ExecutionContext::new(&SCHEME);
 
+        assert_eq!(expr.execute(ctx), false);
+
         ctx.set_field_value("http.host", "EXAMPLE.COM").unwrap();
         assert_eq!(expr.execute(ctx), false);
 
@@ -972,6 +996,8 @@ mod tests {
 
         let expr = expr.compile();
         let ctx = &mut ExecutionContext::new(&SCHEME);
+
+        assert_eq!(expr.execute(ctx), false);
 
         ctx.set_field_value("http.host", "example.org").unwrap();
         assert_eq!(expr.execute(ctx), true);

--- a/engine/src/ast/simple_expr.rs
+++ b/engine/src/ast/simple_expr.rs
@@ -75,9 +75,6 @@ fn test() {
 
     let scheme = &Scheme! { t: Bool };
 
-    let ctx = &mut ExecutionContext::new(scheme);
-    ctx.set_field_value("t", true).unwrap();
-
     let t_expr = SimpleExpr::Field(complete(FieldExpr::lex_with("t", scheme)).unwrap());
     let t_expr = || t_expr.clone();
 
@@ -93,7 +90,11 @@ fn test() {
         );
 
         let expr = expr.compile();
+        let ctx = &mut ExecutionContext::new(scheme);
 
+        assert_eq!(expr.execute(ctx), false);
+
+        ctx.set_field_value("t", true).unwrap();
         assert_eq!(expr.execute(ctx), true);
     }
 
@@ -114,7 +115,11 @@ fn test() {
         );
 
         let expr = expr.compile();
+        let ctx = &mut ExecutionContext::new(scheme);
 
+        assert_eq!(expr.execute(ctx), false);
+
+        ctx.set_field_value("t", true).unwrap();
         assert_eq!(expr.execute(ctx), true);
     }
 
@@ -138,7 +143,11 @@ fn test() {
         );
 
         let expr = expr.compile();
+        let ctx = &mut ExecutionContext::new(scheme);
 
+        assert_eq!(expr.execute(ctx), true);
+
+        ctx.set_field_value("t", true).unwrap();
         assert_eq!(expr.execute(ctx), false);
     }
 
@@ -165,7 +174,11 @@ fn test() {
         );
 
         let expr = expr.compile();
+        let ctx = &mut ExecutionContext::new(scheme);
 
+        assert_eq!(expr.execute(ctx), false);
+
+        ctx.set_field_value("t", true).unwrap();
         assert_eq!(expr.execute(ctx), true);
     }
 

--- a/engine/src/execution_context.rs
+++ b/engine/src/execution_context.rs
@@ -29,22 +29,14 @@ impl<'e> ExecutionContext<'e> {
         self.scheme
     }
 
-    pub(crate) fn get_field_value_unchecked(&'e self, field: Field<'e>) -> LhsValue<'e> {
+    pub(crate) fn get_field_value_unchecked(&'e self, field: Field<'e>) -> Option<LhsValue<'e>> {
         // This is safe because this code is reachable only from Filter::execute
         // which already performs the scheme compatibility check, but check that
         // invariant holds in the future at least in the debug mode.
         debug_assert!(self.scheme() == field.scheme());
 
-        // For now we panic in this, but later we are going to align behaviour
-        // with wireshark: resolve all subexpressions that don't have RHS value
-        // to `false`.
-        let lhs_value = self.values[field.index()].as_ref().unwrap_or_else(|| {
-            panic!(
-                "Field {} was registered but not given a value",
-                field.name()
-            );
-        });
-        lhs_value.as_ref()
+        let lhs_value = self.values.get(field.index())?.as_ref()?;
+        Some(lhs_value.as_ref())
     }
 
     /// Sets a runtime value for a given field name.

--- a/engine/src/functions.rs
+++ b/engine/src/functions.rs
@@ -2,9 +2,9 @@ use crate::types::{LhsValue, Type};
 use std::fmt;
 
 /// An iterator over function arguments as [`LhsValue`]s.
-pub type FunctionArgs<'i, 'a> = &'i mut dyn Iterator<Item = LhsValue<'a>>;
+pub type FunctionArgs<'i, 'a> = &'i mut dyn Iterator<Item = Result<LhsValue<'a>, ()>>;
 
-type FunctionPtr = for<'a> fn(FunctionArgs<'_, 'a>) -> LhsValue<'a>;
+type FunctionPtr = for<'a> fn(FunctionArgs<'_, 'a>) -> Option<LhsValue<'a>>;
 
 /// Wrapper around a function pointer providing the runtime implemetation.
 #[derive(Clone)]
@@ -17,7 +17,10 @@ impl FunctionImpl {
     }
 
     /// Calls the wrapped function pointer.
-    pub fn execute<'a>(&self, args: impl IntoIterator<Item = LhsValue<'a>>) -> LhsValue<'a> {
+    pub fn execute<'a>(
+        &self,
+        args: impl IntoIterator<Item = Result<LhsValue<'a>, ()>>,
+    ) -> Option<LhsValue<'a>> {
         (self.0)(&mut args.into_iter())
     }
 }


### PR DESCRIPTION
None is returned from ExecutionContext::get_field_value and
forwarded back to the execution pipeline until a comparison
operator is found, where it evaluates to false, except for
the inequality operator that evaluates to true.