### PR TITLE
Introduce generic functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "either"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,6 +695,7 @@ dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "cidr 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -748,6 +759,7 @@ dependencies = [
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum csv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71903184af9960c555e7f3b32ff17390d20ecaaf17d4f18c4a0993f2df8a49e3"
 "checksum csv-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4dd8e6d86f7ba48b4276ef1317edc8cc36167546d8972feb4a2b5fec0b374105"
+"checksum derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6073e9676dbebdddeabaeb63e3b7cefd23c86f5c41d381ee1237cc77b1079898"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7efb22686e4a466b1ec1a15c2898f91fa9cb340452496dca654032de20ff95b9"
 "checksum failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "946d0e98a50d9831f5d589038d2ca7f8f455b1c21028c0db0e84116a12696426"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -27,6 +27,7 @@ regex = { version = "1.1.5", optional = true }
 memmem = "0.1.1"
 serde = { version = "1.0.78", features = ["derive"] }
 cfg-if = "0.1.6"
+derivative = "1.0.2"
 
 [dev-dependencies]
 indoc = "0.3.0"

--- a/engine/src/ast/field_expr.rs
+++ b/engine/src/ast/field_expr.rs
@@ -169,7 +169,7 @@ impl<'s> GetType for LhsFieldExpr<'s> {
     fn get_type(&self) -> Type {
         match self {
             LhsFieldExpr::Field(field) => field.get_type(),
-            LhsFieldExpr::FunctionCallExpr(call) => call.function.return_type.clone(),
+            LhsFieldExpr::FunctionCallExpr(call) => call.function.get_type(),
         }
     }
 }

--- a/engine/src/ast/field_expr.rs
+++ b/engine/src/ast/field_expr.rs
@@ -153,6 +153,9 @@ impl<'i, 's> LexWith<'i, &'s Scheme> for LhsFieldExpr<'s> {
     fn lex_with(input: &'i str, scheme: &'s Scheme) -> LexResult<'i, Self> {
         Ok(match FunctionCallExpr::lex_with(input, scheme) {
             Ok((call, input)) => (LhsFieldExpr::FunctionCallExpr(call), input),
+            Err(err @ (LexErrorKind::InvalidArgumentType { .. }, _))
+            | Err(err @ (LexErrorKind::InvalidArgumentKind { .. }, _))
+            | Err(err @ (LexErrorKind::InvalidArgumentsCount { .. }, _)) => Err(err)?,
             // Fallback to field
             Err(_) => {
                 let (field, input) = Field::lex_with(input, scheme)?;

--- a/engine/src/ast/field_expr.rs
+++ b/engine/src/ast/field_expr.rs
@@ -169,7 +169,7 @@ impl<'s> GetType for LhsFieldExpr<'s> {
     fn get_type(&self) -> Type {
         match self {
             LhsFieldExpr::Field(field) => field.get_type(),
-            LhsFieldExpr::FunctionCallExpr(call) => call.function.get_type(),
+            LhsFieldExpr::FunctionCallExpr(call) => call.get_type(),
         }
     }
 }

--- a/engine/src/ast/function_expr.rs
+++ b/engine/src/ast/function_expr.rs
@@ -83,11 +83,13 @@ pub(crate) struct FunctionCallExpr<'s> {
     pub name: String,
     #[serde(skip)]
     #[derivative(PartialEq = "ignore")]
+    #[allow(clippy::borrowed_box)]
     pub function: &'s Box<dyn FunctionDefinition>,
     pub args: Vec<FunctionCallArgExpr<'s>>,
 }
 
 impl<'s> FunctionCallExpr<'s> {
+    #[allow(clippy::borrowed_box)]
     pub fn new(name: &str, function: &'s Box<dyn FunctionDefinition>) -> Self {
         Self {
             name: name.into(),
@@ -114,6 +116,7 @@ impl<'s> FunctionCallExpr<'s> {
     }
 }
 
+#[allow(clippy::borrowed_box)]
 fn invalid_args_count<'i>(function: &Box<dyn FunctionDefinition>, input: &'i str) -> LexError<'i> {
     (
         LexErrorKind::InvalidArgumentsCount {
@@ -150,8 +153,8 @@ impl<'i, 's> LexWith<'i, &'s Scheme> for FunctionCallExpr<'s> {
                     break;
                 }
             } else {
-                input = expect(input, ",")
-                    .map_err(|(_, input)| invalid_args_count(&function, input))?;
+                input =
+                    expect(input, ",").map_err(|(_, input)| invalid_args_count(function, input))?;
             }
 
             input = skip_space(input);

--- a/engine/src/ast/function_expr.rs
+++ b/engine/src/ast/function_expr.rs
@@ -150,6 +150,8 @@ impl<'i, 's> LexWith<'i, &'s Scheme> for FunctionCallExpr<'s> {
 
         let mut function_call = FunctionCallExpr::new(name, function);
 
+        let mut params = Vec::new();
+
         let mut index = 0;
 
         while let Some(c) = input.chars().next() {
@@ -172,7 +174,13 @@ impl<'i, 's> LexWith<'i, &'s Scheme> for FunctionCallExpr<'s> {
             };
 
             let param = function
-                .check_param(index, &next_param)
+                .check_param(
+                    &mut (&function_call.args).iter().map(|arg| FunctionParam {
+                        arg_kind: arg.get_kind(),
+                        val_type: arg.get_type(),
+                    }),
+                    &next_param,
+                )
                 .ok_or_else(|| invalid_args_count(function, input))?;
 
             if next_param.arg_kind != param.arg_kind {
@@ -200,6 +208,8 @@ impl<'i, 's> LexWith<'i, &'s Scheme> for FunctionCallExpr<'s> {
                     span(input, rest),
                 ));
             }
+
+            params.push(param);
 
             function_call.args.push(arg);
 

--- a/engine/src/ast/function_expr.rs
+++ b/engine/src/ast/function_expr.rs
@@ -128,6 +128,16 @@ fn invalid_args_count<'i>(function: &Box<dyn FunctionDefinition>, input: &'i str
     )
 }
 
+impl<'s> GetType for FunctionCallExpr<'s> {
+    fn get_type(&self) -> Type {
+        self.function
+            .return_type(&mut (&self.args).iter().map(|arg| FunctionParam {
+                arg_kind: arg.get_kind(),
+                val_type: arg.get_type(),
+            }))
+    }
+}
+
 impl<'i, 's> LexWith<'i, &'s Scheme> for FunctionCallExpr<'s> {
     fn lex_with(input: &'i str, scheme: &'s Scheme) -> LexResult<'i, Self> {
         let initial_input = input;

--- a/engine/src/functions.rs
+++ b/engine/src/functions.rs
@@ -81,9 +81,13 @@ pub struct FunctionOptParam {
 
 /// Trait to implement function
 pub trait FunctionDefinition: GetType + Debug + Sync + Send {
-    /// Check if the parameter specified at index `index` is correct.
-    /// Return the expected the parameter definition.
-    fn check_param(&self, index: usize, param: &FunctionParam) -> Option<FunctionParam>;
+    /// Given a slice of already checked parameters, checks that next_param is
+    /// correct. Return the expected the parameter definition.
+    fn check_param(
+        &self,
+        params: &mut ExactSizeIterator<Item = FunctionParam>,
+        next_param: &FunctionParam,
+    ) -> Option<FunctionParam>;
     /// Number of mandatory arguments and number of optional arguments
     /// (N, Some(0)) means N mandatory arguments and no optional arguments
     /// (N, None) means N mandatory arguments and unlimited optional arguments
@@ -114,7 +118,12 @@ impl GetType for Function {
 }
 
 impl FunctionDefinition for Function {
-    fn check_param(&self, index: usize, _: &FunctionParam) -> Option<FunctionParam> {
+    fn check_param(
+        &self,
+        params: &mut ExactSizeIterator<Item = FunctionParam>,
+        _: &FunctionParam,
+    ) -> Option<FunctionParam> {
+        let index = params.len();
         if index < self.params.len() {
             return self.params.get(index).cloned();
         } else if index < self.params.len() + self.opt_params.len() {

--- a/engine/src/functions.rs
+++ b/engine/src/functions.rs
@@ -84,10 +84,10 @@ pub trait FunctionDefinition: GetType + Debug + Sync + Send {
     /// Check if the parameter specified at index `index` is correct.
     /// Return the expected the parameter definition.
     fn check_param(&self, index: usize, param: &FunctionParam) -> Option<FunctionParam>;
-    /// Minimum number of arguments needed by the function.
-    fn min_arg_count(&self) -> usize;
-    /// Maximum number of arguments needed by the function.
-    fn max_arg_count(&self) -> Option<usize>;
+    /// Number of mandatory arguments and number of optional arguments
+    /// (N, Some(0)) means N mandatory arguments and no optional arguments
+    /// (N, None) means N mandatory arguments and unlimited optional arguments
+    fn arg_count(&self) -> (usize, Option<usize>);
     /// Get default value for optional arguments.
     fn default_value(&self, index: usize) -> Option<LhsValue>;
     /// Execute the real implementation.
@@ -129,12 +129,8 @@ impl FunctionDefinition for Function {
         None
     }
 
-    fn min_arg_count(&self) -> usize {
-        self.params.len()
-    }
-
-    fn max_arg_count(&self) -> Option<usize> {
-        Some(self.params.len() + self.opt_params.len())
+    fn arg_count(&self) -> (usize, Option<usize>) {
+        (self.params.len(), Some(self.opt_params.len()))
     }
 
     fn default_value(&self, index: usize) -> Option<LhsValue> {

--- a/engine/src/functions.rs
+++ b/engine/src/functions.rs
@@ -1,4 +1,5 @@
 use crate::types::{LhsValue, Type};
+use failure::Fail;
 use std::fmt;
 
 /// An iterator over function arguments as [`LhsValue`]s.
@@ -39,12 +40,25 @@ impl PartialEq for FunctionImpl {
 impl Eq for FunctionImpl {}
 
 /// Defines what kind of argument a function expects.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum FunctionArgKind {
     /// Allow only literal as argument.
     Literal,
     /// Allow only field as argument.
     Field,
+}
+
+/// An error that occurs on a kind mismatch.
+#[derive(Debug, PartialEq, Fail)]
+#[fail(
+    display = "expected argument of kind {:?}, but got {:?}",
+    expected, actual
+)]
+pub struct FunctionArgKindMismatchError {
+    /// Expected value type.
+    pub expected: FunctionArgKind,
+    /// Provided value type.
+    pub actual: FunctionArgKind,
 }
 
 /// Defines a mandatory function argument.

--- a/engine/src/functions.rs
+++ b/engine/src/functions.rs
@@ -80,7 +80,7 @@ pub struct FunctionOptParam {
 }
 
 /// Trait to implement function
-pub trait FunctionDefinition: GetType + Debug + Sync + Send {
+pub trait FunctionDefinition: Debug + Sync + Send {
     /// Given a slice of already checked parameters, checks that next_param is
     /// correct. Return the expected the parameter definition.
     fn check_param(
@@ -88,6 +88,8 @@ pub trait FunctionDefinition: GetType + Debug + Sync + Send {
         params: &mut ExactSizeIterator<Item = FunctionParam>,
         next_param: &FunctionParam,
     ) -> Option<FunctionParam>;
+    /// Function return type.
+    fn return_type(&self, params: &mut ExactSizeIterator<Item = FunctionParam>) -> Type;
     /// Number of mandatory arguments and number of optional arguments
     /// (N, Some(0)) means N mandatory arguments and no optional arguments
     /// (N, None) means N mandatory arguments and unlimited optional arguments
@@ -111,12 +113,6 @@ pub struct Function {
     pub implementation: FunctionImpl,
 }
 
-impl GetType for Function {
-    fn get_type(&self) -> Type {
-        self.return_type.clone()
-    }
-}
-
 impl FunctionDefinition for Function {
     fn check_param(
         &self,
@@ -136,6 +132,10 @@ impl FunctionDefinition for Function {
                 });
         }
         None
+    }
+
+    fn return_type(&self, _: &mut ExactSizeIterator<Item = FunctionParam>) -> Type {
+        self.return_type.clone()
     }
 
     fn arg_count(&self) -> (usize, Option<usize>) {

--- a/engine/src/functions.rs
+++ b/engine/src/functions.rs
@@ -1,13 +1,13 @@
-use crate::types::{LhsValue, Type};
+use crate::types::{GetType, LhsValue, Type};
 use failure::Fail;
-use std::fmt;
+use std::fmt::{self, Debug};
 
 /// An iterator over function arguments as [`LhsValue`]s.
 pub type FunctionArgs<'i, 'a> = &'i mut dyn Iterator<Item = LhsValue<'a>>;
 
 type FunctionPtr = for<'a> fn(FunctionArgs<'_, 'a>) -> LhsValue<'a>;
 
-/// Wrapper around a function pointer providing the runtime implemetation.
+/// Wrapper around a function pointer providing the runtime implementation.
 #[derive(Clone)]
 pub struct FunctionImpl(FunctionPtr);
 
@@ -18,8 +18,8 @@ impl FunctionImpl {
     }
 
     /// Calls the wrapped function pointer.
-    pub fn execute<'a>(&self, args: impl IntoIterator<Item = LhsValue<'a>>) -> LhsValue<'a> {
-        (self.0)(&mut args.into_iter())
+    pub fn execute<'a>(&self, args: FunctionArgs<'_, 'a>) -> LhsValue<'a> {
+        (self.0)(args)
     }
 }
 
@@ -79,6 +79,21 @@ pub struct FunctionOptParam {
     pub default_value: LhsValue<'static>,
 }
 
+/// Trait to implement function
+pub trait FunctionDefinition: GetType + Debug + Sync + Send {
+    /// Check if the parameter specified at index `index` is correct.
+    /// Return the expected the parameter definition.
+    fn check_param(&self, index: usize, param: &FunctionParam) -> Option<FunctionParam>;
+    /// Minimum number of arguments needed by the function.
+    fn min_arg_count(&self) -> usize;
+    /// Maximum number of arguments needed by the function.
+    fn max_arg_count(&self) -> Option<usize>;
+    /// Get default value for optional arguments.
+    fn default_value(&self, index: usize) -> Option<LhsValue>;
+    /// Execute the real implementation.
+    fn execute<'a>(&self, args: FunctionArgs<'_, 'a>) -> LhsValue<'a>;
+}
+
 /// Defines a function.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Function {
@@ -90,4 +105,45 @@ pub struct Function {
     pub return_type: Type,
     /// Actual implementation that will be called at runtime.
     pub implementation: FunctionImpl,
+}
+
+impl GetType for Function {
+    fn get_type(&self) -> Type {
+        self.return_type.clone()
+    }
+}
+
+impl FunctionDefinition for Function {
+    fn check_param(&self, index: usize, _: &FunctionParam) -> Option<FunctionParam> {
+        if index < self.params.len() {
+            return self.params.get(index).cloned();
+        } else if index < self.params.len() + self.opt_params.len() {
+            return self
+                .opt_params
+                .get(index - self.params.len())
+                .map(|opt_param| FunctionParam {
+                    arg_kind: opt_param.arg_kind,
+                    val_type: opt_param.default_value.get_type(),
+                });
+        }
+        None
+    }
+
+    fn min_arg_count(&self) -> usize {
+        self.params.len()
+    }
+
+    fn max_arg_count(&self) -> Option<usize> {
+        Some(self.params.len() + self.opt_params.len())
+    }
+
+    fn default_value(&self, index: usize) -> Option<LhsValue> {
+        self.opt_params
+            .get(index - self.params.len())
+            .map(|opt_param| opt_param.default_value.as_ref())
+    }
+
+    fn execute<'a>(&self, args: FunctionArgs<'_, 'a>) -> LhsValue<'a> {
+        self.implementation.execute(args)
+    }
 }

--- a/engine/src/lex.rs
+++ b/engine/src/lex.rs
@@ -1,4 +1,5 @@
 use crate::{
+    functions::FunctionArgKindMismatchError,
     rhs_types::RegexError,
     scheme::{IndexAccessError, UnknownFieldError, UnknownFunctionError},
     types::{Type, TypeMismatchError},
@@ -60,6 +61,13 @@ pub enum LexErrorKind {
     InvalidArgumentsCount {
         expected_min: usize,
         expected_max: usize,
+    },
+
+    #[fail(display = "invalid kind of argument #{}: {}", index, mismatch)]
+    InvalidArgumentKind {
+        index: usize,
+        #[cause]
+        mismatch: FunctionArgKindMismatchError,
     },
 
     #[fail(display = "invalid type of argument #{}: {}", index, mismatch)]

--- a/engine/src/lex.rs
+++ b/engine/src/lex.rs
@@ -60,7 +60,7 @@ pub enum LexErrorKind {
     #[fail(display = "invalid number of arguments")]
     InvalidArgumentsCount {
         expected_min: usize,
-        expected_max: usize,
+        expected_max: Option<usize>,
     },
 
     #[fail(display = "invalid kind of argument #{}: {}", index, mismatch)]

--- a/engine/src/scheme.rs
+++ b/engine/src/scheme.rs
@@ -349,6 +349,7 @@ impl<'s> Scheme {
         Ok(())
     }
 
+    #[allow(clippy::borrowed_box)]
     pub(crate) fn get_function(
         &'s self,
         name: &str,


### PR DESCRIPTION
This RFC is meant to introduce generic functions. Generic functions are functions whose prototype is not entirely known in advance but instead depends of the argument itself. This includes:
* variadic functions, like `concat`
* function that can accept different argument type but where arguments have constraints between each other
* when arrays will be introduced, functions that can accept array of any type.

This proposal relies on a newly introduced `FunctionDefinition` trait who provides an abstract interface to validate and execute function calls.

On a side note, function argument parsing have been modified. Each argument is blindly parsed then passed to the trait in order to validate it.
Parsing is now done is this order for each argument:
* try to parse a field or a nested function call
* try to parse an `Ip` literal
* try to parse an `Integer` literal
* try to parse a `Bytes` literal

Valid hexadecimal integer such as `10` can be parsed as `Integer`or as `Bytes`. `Integer` is parsed before `Bytes` as its most likely what a human would expect.