### PR TITLE
Improve array type

### DIFF
--- a/engine/src/types.rs
+++ b/engine/src/types.rs
@@ -258,6 +258,14 @@ impl<'a> GetType for Array<'a> {
     }
 }
 
+impl<'a> IntoIterator for Array<'a> {
+    type Item = LhsValue<'a>;
+    type IntoIter = std::vec::IntoIter<LhsValue<'a>>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.into_iter()
+    }
+}
+
 /// A map of string to [`Type`].
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct Map<'a> {

--- a/engine/src/types.rs
+++ b/engine/src/types.rs
@@ -245,6 +245,11 @@ impl<'a> Array<'a> {
         }
         arr
     }
+
+    /// Returns the type of the contained values.
+    pub fn value_type(&self) -> &Type {
+        &self.val_type
+    }
 }
 
 impl<'a> GetType for Array<'a> {
@@ -298,6 +303,11 @@ impl<'a> Map<'a> {
             map.data.insert(k.clone(), v.to_owned());
         }
         map
+    }
+
+    /// Returns the type of the contained values.
+    pub fn value_type(&self) -> &Type {
+        &self.val_type
     }
 }
 


### PR DESCRIPTION
* add `value_type()` method in order to get the `Type` of the values contained in an `Array` (same was done for `Map` for coherence)
* implement `IntoIterator` trait to be able to iterate over the values contained in an `Array`