### PR TITLE
Re-add TryFrom implementation to LhsValue

### DIFF
--- a/engine/src/ast/function_expr.rs
+++ b/engine/src/ast/function_expr.rs
@@ -50,7 +50,7 @@ impl<'i, 's, 'a> LexWith<'i, SchemeFunctionParam<'s, 'a>> for FunctionCallArgExp
                             index: ctx.index,
                             mismatch: TypeMismatchError {
                                 actual: lhs.get_type(),
-                                expected: ctx.param.val_type.clone(),
+                                expected: ctx.param.val_type.clone().into(),
                             },
                         },
                         span(initial_input, input),
@@ -349,7 +349,7 @@ fn test_function() {
             index: 0,
             mismatch: TypeMismatchError {
                 actual: Type::Ip,
-                expected: Type::Bytes,
+                expected: Type::Bytes.into(),
             }
         },
         "ip.addr"

--- a/engine/src/execution_context.rs
+++ b/engine/src/execution_context.rs
@@ -64,7 +64,7 @@ impl<'e> ExecutionContext<'e> {
             Ok(())
         } else {
             Err(TypeMismatchError {
-                expected: field_type,
+                expected: field_type.into(),
                 actual: value_type,
             })
         }
@@ -82,7 +82,7 @@ fn test_field_value_type_mismatch() {
     assert_eq!(
         ctx.set_field_value("foo", LhsValue::Bool(false)),
         Err(TypeMismatchError {
-            expected: Type::Int,
+            expected: Type::Int.into(),
             actual: Type::Bool
         })
     );

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -79,5 +79,5 @@ pub use self::{
         Function, FunctionArgKind, FunctionArgs, FunctionImpl, FunctionOptParam, FunctionParam,
     },
     scheme::{FieldIndex, FieldRedefinitionError, ParseError, Scheme, UnknownFieldError},
-    types::{GetType, LhsValue, Map, Type, TypeMismatchError},
+    types::{ExpectedTypeMismatch, GetType, LhsValue, Map, Type, TypeMismatchError},
 };


### PR DESCRIPTION
This was deleted when working on the Map & Array data types.
See e500dc1f5f80c38273d2436f9fe82cff7fef3c40 for more info.