### PR TITLE
FW-1301: Fix error handling for checking generic functions

### DIFF
--- a/engine/benches/bench.rs
+++ b/engine/benches/bench.rs
@@ -213,7 +213,7 @@ fn bench_string_function_comparison(c: &mut Criterion) {
                 Function {
                     params: vec![FunctionParam {
                         arg_kind: FunctionArgKind::Field,
-                        val_type: Type::Bytes,
+                        arg_type: Type::Bytes,
                     }],
                     opt_params: vec![],
                     return_type: Type::Bytes,
@@ -225,7 +225,7 @@ fn bench_string_function_comparison(c: &mut Criterion) {
                 Function {
                     params: vec![FunctionParam {
                         arg_kind: FunctionArgKind::Field,
-                        val_type: Type::Bytes,
+                        arg_type: Type::Bytes,
                     }],
                     opt_params: vec![],
                     return_type: Type::Bytes,

--- a/engine/examples/cli.rs
+++ b/engine/examples/cli.rs
@@ -26,7 +26,7 @@ fn main() {
             Function {
                 params: vec![FunctionParam {
                     arg_kind: FunctionArgKind::Field,
-                    val_type: Type::Bytes,
+                    arg_type: Type::Bytes,
                 }],
                 opt_params: vec![FunctionOptParam {
                     arg_kind: FunctionArgKind::Literal,


### PR DESCRIPTION
Fix an issue where a function that received arguments of incorrect type caused an error that not enough arguments were present.