### PR TITLE
Filter and ExecutionContext do not need the same lifetime

### DIFF
--- a/engine/src/filter.rs
+++ b/engine/src/filter.rs
@@ -54,7 +54,7 @@ impl<'s> Filter<'s> {
     }
 
     /// Executes a filter against a provided context with values.
-    pub fn execute(&self, ctx: &ExecutionContext<'s>) -> Result<bool, SchemeMismatchError> {
+    pub fn execute(&self, ctx: &ExecutionContext) -> Result<bool, SchemeMismatchError> {
         if self.scheme == ctx.scheme() {
             Ok(self.root_expr.execute(ctx))
         } else {


### PR DESCRIPTION
There is no reason these need the same lifetime, and requiring the same
lifetime makes some things impossible like having a Filter with a
'static lifetime and trying to execute against an ExecutionContext that
was built with dynamic Strings.