### PR TITLE
fix Type resolution in Scheme macro

### DIFF
--- a/engine/src/scheme.rs
+++ b/engine/src/scheme.rs
@@ -684,7 +684,7 @@ macro_rules! Scheme {
         // Treat duplciations in static schemes as a developer's mistake.
         .unwrap_or_else(|err| panic!("{}", err))
     };
-    ($ty:ident $(($subty:tt $($rest:tt)*))?) => {crate::Type::$ty$((Box::new(Scheme!($subty $($rest)*))))?};
+    ($ty:ident $(($subty:tt $($rest:tt)*))?) => {$crate::Type::$ty$((Box::new(Scheme!($subty $($rest)*))))?};
 }
 
 #[test]


### PR DESCRIPTION
Type should be used from wirefilter:: instead of current crate