### PR TITLE
Don't panic on missing subexpressions

### DIFF
--- a/engine/src/ast/index_expr.rs
+++ b/engine/src/ast/index_expr.rs
@@ -178,16 +178,16 @@ impl<'s> IndexExpr<'s> {
             }
             LhsFieldExpr::Field(f) => {
                 if indexes.is_empty() {
-                    CompiledOneExpr::new(move |ctx| func(ctx.get_field_value_unchecked(f), ctx))
+                    CompiledOneExpr::new(move |ctx| {
+                        if let Some(value) = ctx.get_field_value(f) {
+                            func(value, ctx)
+                        } else {
+                            false
+                        }
+                    })
                 } else {
                     CompiledOneExpr::new(move |ctx| {
-                        index_access_one!(
-                            indexes,
-                            Some(ctx.get_field_value_unchecked(f)),
-                            default,
-                            ctx,
-                            func
-                        )
+                        index_access_one!(indexes, ctx.get_field_value(f), default, ctx, func)
                     })
                 }
             }


### PR DESCRIPTION
Hi! Thanks for the project, currently `Filter#execute` will panic with `thread 'main' panicked at 'Field xxx was registered but not given a value'`, if a field in the `Scheme` is not set on the `ExecutionContext`. This PR changes it so that instead it will not match the `ExecutionContext` (i think).