### PR TITLE
fix checking  matchers

### DIFF
--- a/engine/src/list_matcher.rs
+++ b/engine/src/list_matcher.rs
@@ -174,7 +174,7 @@ impl ListDefinition for NeverList {
     }
 
     fn is_valid_matcher(&self, matcher: &dyn Any) -> bool {
-        matcher.is::<AlwaysListMatcher>()
+        matcher.is::<NeverListMatcher>()
     }
 }
 


### PR DESCRIPTION
While looking at the list implementation, I noticed a small issue where the validity check of `NeverList` seems to not match `NeverListMatcher`. 