### PR TITLE
Expose `CompoundType` publicly

### DIFF
--- a/engine/src/lhs_types/array.rs
+++ b/engine/src/lhs_types/array.rs
@@ -581,15 +581,8 @@ impl<'a, V: IntoValue<'a>> FromIterator<V> for TypedArray<'a, V> {
     }
 }
 
-const fn compound_from_type(ty: Type) -> CompoundType {
-    match CompoundType::from_type(ty) {
-        Some(ty) => ty,
-        None => panic!("Could not convert type to compound type"),
-    }
-}
-
 impl<'a, V: IntoValue<'a>> IntoValue<'a> for TypedArray<'a, V> {
-    const TYPE: Type = Type::Array(compound_from_type(V::TYPE));
+    const TYPE: Type = Type::Array(CompoundType::from_type(V::TYPE));
 
     #[inline]
     fn into_value(self) -> LhsValue<'a> {

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -120,7 +120,7 @@ pub use self::{
         UnknownFieldError,
     },
     types::{
-        ExpectedType, ExpectedTypeList, GetType, LhsValue, LhsValueMut, RhsValue, RhsValues, Type,
-        TypeMismatchError,
+        CompoundType, ExpectedType, ExpectedTypeList, GetType, LhsValue, LhsValueMut, RhsValue,
+        RhsValues, Type, TypeMismatchError,
     },
 };

--- a/engine/src/types.rs
+++ b/engine/src/types.rs
@@ -41,11 +41,11 @@ pub enum ExpectedType {
     /// Fully identified expected type
     Type(Type),
     /// Loosely identified array type
-    /// Usefull when expecting an array without
+    /// Useful when expecting an array without
     /// knowing of which specific value type
     Array,
     /// Loosely identified map type
-    /// Usefull when expecting a map without
+    /// Useful when expecting a map without
     /// knowing of which specific value type
     Map,
 }
@@ -986,6 +986,8 @@ enum Layer {
     Map,
 }
 
+/// A type for field values that stores a recursive type in a flattened form. It
+/// is particularly useful for creating nested types such as arrays or maps.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct CompoundType {
     layers: u32,
@@ -1023,15 +1025,19 @@ impl CompoundType {
         }
     }
 
+    /// Converts a [`Type`] into a [`CompoundType`].
     #[inline]
-    pub(crate) const fn from_type(ty: Type) -> Option<Self> {
-        match ty {
+    pub const fn from_type(ty: Type) -> Self {
+        match match ty {
             Type::Bool => Some(Self::new(PrimitiveType::Bool)),
             Type::Bytes => Some(Self::new(PrimitiveType::Bytes)),
             Type::Int => Some(Self::new(PrimitiveType::Int)),
             Type::Ip => Some(Self::new(PrimitiveType::Ip)),
             Type::Array(ty) => ty.push(Layer::Array),
             Type::Map(ty) => ty.push(Layer::Map),
+        } {
+            Some(ty) => ty,
+            None => panic!("Could not convert type to compound type"),
         }
     }
 
@@ -1078,7 +1084,7 @@ impl From<PrimitiveType> for CompoundType {
 impl From<Type> for CompoundType {
     #[inline]
     fn from(ty: Type) -> Self {
-        Self::from_type(ty).unwrap()
+        Self::from_type(ty)
     }
 }
 


### PR DESCRIPTION
This is needed to be able to construct more advanced types, such as arrays and maps, using the public API.

Also make the `CompoundType::from_type` function publicly so it is possible to construct compound types in public functions using the public API.