### PR TITLE
allow missing (optional) fields

### DIFF
--- a/engine/src/ast/field_expr.rs
+++ b/engine/src/ast/field_expr.rs
@@ -248,7 +248,10 @@ impl<'s> IdentifierExpr<'s> {
     ) -> CompiledValueExpr<'s, C::U> {
         match self {
             IdentifierExpr::Field(f) => {
-                CompiledValueExpr::new(move |ctx| Ok(ctx.get_field_value_unchecked(f).as_ref()))
+                CompiledValueExpr::new(move |ctx| match ctx.get_field_value(f) {
+                    Some(value) => Ok(value.as_ref()),
+                    None => Err(f.get_type()),
+                })
             }
             IdentifierExpr::FunctionCallExpr(call) => compiler.compile_function_call_expr(call),
         }

--- a/engine/src/execution_context.rs
+++ b/engine/src/execution_context.rs
@@ -99,24 +99,6 @@ impl<'e, U> ExecutionContext<'e, U> {
         }
     }
 
-    #[inline]
-    pub(crate) fn get_field_value_unchecked(&self, field: Field<'_>) -> &LhsValue<'_> {
-        // This is safe because this code is reachable only from Filter::execute
-        // which already performs the scheme compatibility check, but check that
-        // invariant holds in the future at least in the debug mode.
-        debug_assert!(self.scheme() == field.scheme());
-
-        // For now we panic in this, but later we are going to align behaviour
-        // with wireshark: resolve all subexpressions that don't have RHS value
-        // to `false`.
-        self.values[field.index()].as_ref().unwrap_or_else(|| {
-            panic!(
-                "Field {} was registered but not given a value",
-                field.name()
-            );
-        })
-    }
-
     /// Get the value of a field.
     pub fn get_field_value(&self, field: Field<'_>) -> Option<&LhsValue<'_>> {
         assert!(self.scheme() == field.scheme());


### PR DESCRIPTION
it's a common use case to have optional fields in schema.

instead of panicking in case of evaluating missing fields, simply evaluate the expression as false.