### PR TITLE
Inline `IdentifierExpr::compile_with_compiler` in `IndexExpr::compile_with_compiler`

### DIFF
--- a/engine/src/ast/field_expr.rs
+++ b/engine/src/ast/field_expr.rs
@@ -7,7 +7,7 @@ use super::{
 use crate::{
     ast::index_expr::IndexExpr,
     compiler::Compiler,
-    filter::{CompiledExpr, CompiledValueExpr},
+    filter::CompiledExpr,
     lex::{expect, skip_space, span, Lex, LexErrorKind, LexResult, LexWith},
     range_set::RangeSet,
     rhs_types::{Bytes, ExplicitIpRange, ListName, Regex, Wildcard},
@@ -239,20 +239,6 @@ pub enum IdentifierExpr<'s> {
     Field(Field<'s>),
     /// Function call
     FunctionCallExpr(FunctionCallExpr<'s>),
-}
-
-impl<'s> IdentifierExpr<'s> {
-    pub(crate) fn compile_with_compiler<C: Compiler<'s> + 's>(
-        self,
-        compiler: &mut C,
-    ) -> CompiledValueExpr<'s, C::U> {
-        match self {
-            IdentifierExpr::Field(f) => {
-                CompiledValueExpr::new(move |ctx| Ok(ctx.get_field_value_unchecked(f).as_ref()))
-            }
-            IdentifierExpr::FunctionCallExpr(call) => compiler.compile_function_call_expr(call),
-        }
-    }
 }
 
 impl<'i, 's> LexWith<'i, &FilterParser<'s>> for IdentifierExpr<'s> {

--- a/engine/src/ast/index_expr.rs
+++ b/engine/src/ast/index_expr.rs
@@ -112,7 +112,12 @@ impl<'s> ValueExpr<'s> for IndexExpr<'s> {
         };
         if last == Some(0) {
             // Fast path
-            identifier.compile_with_compiler(compiler)
+            match identifier {
+                IdentifierExpr::Field(f) => {
+                    CompiledValueExpr::new(move |ctx| Ok(ctx.get_field_value_unchecked(f).as_ref()))
+                }
+                IdentifierExpr::FunctionCallExpr(call) => compiler.compile_function_call_expr(call),
+            }
         } else if let Some(last) = last {
             // Average path
             match identifier {


### PR DESCRIPTION


Other cases are already inline so this makes the code more consistent and easier to reason about.