### PR TITLE
Only pass parser settings when checking function parameters.

### DIFF
--- a/engine/src/ast/field_expr.rs
+++ b/engine/src/ast/field_expr.rs
@@ -645,8 +645,10 @@ impl<'s> Expr<'s> for ComparisonExpr<'s> {
 mod tests {
     use super::*;
     use crate::{
-        ast::function_expr::{FunctionCallArgExpr, FunctionCallExpr},
-        ast::logical_expr::LogicalExpr,
+        ast::{
+            function_expr::{FunctionCallArgExpr, FunctionCallExpr},
+            logical_expr::LogicalExpr,
+        },
         execution_context::ExecutionContext,
         functions::{
             FunctionArgKind, FunctionArgs, FunctionDefinition, FunctionDefinitionContext,
@@ -658,7 +660,7 @@ mod tests {
         rhs_types::{IpRange, RegexFormat},
         scheme::{FieldIndex, IndexAccessError, Scheme},
         types::ExpectedType,
-        BytesFormat,
+        BytesFormat, ParserSettings,
     };
     use cidr::IpCidr;
     use std::sync::LazyLock;
@@ -715,7 +717,7 @@ mod tests {
     impl FunctionDefinition for FilterFunction {
         fn check_param(
             &self,
-            _: &FilterParser<'_>,
+            _: &ParserSettings,
             params: &mut dyn ExactSizeIterator<Item = FunctionParam<'_>>,
             next_param: &FunctionParam<'_>,
             _: Option<&mut FunctionDefinitionContext>,

--- a/engine/src/ast/function_expr.rs
+++ b/engine/src/ast/function_expr.rs
@@ -418,7 +418,7 @@ impl<'s> FunctionCallExpr<'s> {
 
             definition
                 .check_param(
-                    parser,
+                    parser.settings(),
                     &mut args.iter().map(|arg| arg.into()),
                     &next_param,
                     ctx.as_mut(),

--- a/engine/src/functions.rs
+++ b/engine/src/functions.rs
@@ -1,7 +1,7 @@
 use crate::{
     filter::CompiledValueResult,
     types::{ExpectedType, ExpectedTypeList, GetType, LhsValue, RhsValue, Type, TypeMismatchError},
-    FilterParser,
+    ParserSettings,
 };
 use std::any::Any;
 use std::convert::TryFrom;
@@ -371,7 +371,7 @@ pub trait FunctionDefinition: Debug + Send + Sync {
     /// correct. Return the expected the parameter definition.
     fn check_param(
         &self,
-        parser: &FilterParser<'_>,
+        settings: &ParserSettings,
         params: &mut dyn ExactSizeIterator<Item = FunctionParam<'_>>,
         next_param: &FunctionParam<'_>,
         ctx: Option<&mut FunctionDefinitionContext>,
@@ -460,7 +460,7 @@ pub struct SimpleFunctionDefinition {
 impl FunctionDefinition for SimpleFunctionDefinition {
     fn check_param(
         &self,
-        _parser: &FilterParser<'_>,
+        _settings: &ParserSettings,
         params: &mut dyn ExactSizeIterator<Item = FunctionParam<'_>>,
         next_param: &FunctionParam<'_>,
         _: Option<&mut FunctionDefinitionContext>,

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -84,7 +84,7 @@ pub use self::{
         function_expr::{FunctionCallArgExpr, FunctionCallExpr},
         index_expr::IndexExpr,
         logical_expr::{LogicalExpr, LogicalOp, ParenthesizedExpr, UnaryOp},
-        parse::{FilterParser, ParseError},
+        parse::{FilterParser, ParseError, ParserSettings},
         visitor::{Visitor, VisitorMut},
         Expr, FilterAst, FilterValueAst, ValueExpr,
     },

--- a/engine/src/rhs_types/regex/imp_real.rs
+++ b/engine/src/rhs_types/regex/imp_real.rs
@@ -18,8 +18,8 @@ impl Regex {
     ) -> Result<Self, Error> {
         ::regex::bytes::RegexBuilder::new(pattern)
             .unicode(false)
-            .size_limit(parser.regex_compiled_size_limit)
-            .dfa_size_limit(parser.regex_dfa_size_limit)
+            .size_limit(parser.settings.regex_compiled_size_limit)
+            .dfa_size_limit(parser.settings.regex_dfa_size_limit)
             .build()
             .map(|r| Regex {
                 compiled_regex: r,

--- a/engine/src/rhs_types/wildcard.rs
+++ b/engine/src/rhs_types/wildcard.rs
@@ -126,7 +126,7 @@ impl<const STRICT: bool> Serialize for Wildcard<STRICT> {
 impl<'i, 's, const STRICT: bool> LexWith<'i, &FilterParser<'s>> for Wildcard<STRICT> {
     fn lex_with(input: &'i str, parser: &FilterParser<'s>) -> LexResult<'i, Wildcard<STRICT>> {
         lex_quoted_or_raw_string(input).and_then(|(pattern, rest)| {
-            match Wildcard::new(pattern, parser.wildcard_star_limit) {
+            match Wildcard::new(pattern, parser.settings.wildcard_star_limit) {
                 Ok(wildcard) => Ok((wildcard, rest)),
                 Err(err) => Err((LexErrorKind::ParseWildcard(err), input)),
             }

--- a/engine/src/scheme.rs
+++ b/engine/src/scheme.rs
@@ -1,6 +1,8 @@
 use crate::{
-    ast::parse::{FilterParser, ParseError},
-    ast::{FilterAst, FilterValueAst},
+    ast::{
+        parse::{FilterParser, ParseError, ParserSettings},
+        FilterAst, FilterValueAst,
+    },
     functions::FunctionDefinition,
     lex::{expect, span, take_while, Lex, LexErrorKind, LexResult, LexWith},
     list_matcher::ListDefinition,
@@ -534,6 +536,16 @@ impl<'s> Scheme {
             scheme: self,
             index,
         })
+    }
+
+    /// Creates a new parser with default settings.
+    pub fn parser(&self) -> FilterParser<'_> {
+        FilterParser::new(self)
+    }
+
+    /// Creates a new parser with the specified settings.
+    pub fn parser_with_settings(&self, settings: ParserSettings) -> FilterParser<'_> {
+        FilterParser::with_settings(self, settings)
     }
 
     /// Parses a filter expression into an AST form.


### PR DESCRIPTION
Passing the whole parser allows to access too many things, like the scheme and potentially other things we might add in the future. It also makes writing unit tests more cumbersome since we now have to build a scheme first just to get a dummy parser.