### PR TITLE
Use reference counted scheme instead of references

### DIFF
--- a/engine/src/ast/mod.rs
+++ b/engine/src/ast/mod.rs
@@ -20,40 +20,34 @@ use std::fmt::{self, Debug};
 use visitor::{UsesListVisitor, UsesVisitor, Visitor, VisitorMut};
 
 /// Trait used to represent node that evaluates to a [`bool`] (or a [`Vec<bool>`]).
-pub trait Expr<'s>:
-    Sized + Eq + Debug + for<'i, 'p> LexWith<'i, &'p FilterParser<'s>> + Serialize
+pub trait Expr:
+    Sized + Eq + Debug + for<'i, 'p, 's> LexWith<'i, &'p FilterParser<'s>> + Serialize
 {
     /// Recursively visit all nodes in the AST using a [`Visitor`].
-    fn walk<'a, V: Visitor<'s, 'a>>(&'a self, visitor: &mut V);
+    fn walk<'a, V: Visitor<'a>>(&'a self, visitor: &mut V);
     /// Recursively visit all nodes in the AST using a [`VisitorMut`].
-    fn walk_mut<'a, V: VisitorMut<'s, 'a>>(&'a mut self, visitor: &mut V);
+    fn walk_mut<'a, V: VisitorMut<'a>>(&'a mut self, visitor: &mut V);
     /// Compiles current node into a [`CompiledExpr`] using [`Compiler`].
-    fn compile_with_compiler<C: Compiler<'s> + 's>(
-        self,
-        compiler: &mut C,
-    ) -> CompiledExpr<'s, C::U>;
+    fn compile_with_compiler<C: Compiler>(self, compiler: &mut C) -> CompiledExpr<C::U>;
     /// Compiles current node into a [`CompiledExpr`] using [`DefaultCompiler`].
-    fn compile(self) -> CompiledExpr<'s> {
+    fn compile(self) -> CompiledExpr {
         let mut compiler = DefaultCompiler::new();
         self.compile_with_compiler(&mut compiler)
     }
 }
 
 /// Trait used to represent node that evaluates to an [`crate::LhsValue`].
-pub trait ValueExpr<'s>:
-    Sized + Eq + Debug + for<'i, 'p> LexWith<'i, &'p FilterParser<'s>> + Serialize
+pub trait ValueExpr:
+    Sized + Eq + Debug + for<'i, 'p, 's> LexWith<'i, &'p FilterParser<'s>> + Serialize
 {
     /// Recursively visit all nodes in the AST using a [`Visitor`].
-    fn walk<'a, V: Visitor<'s, 'a>>(&'a self, visitor: &mut V);
+    fn walk<'a, V: Visitor<'a>>(&'a self, visitor: &mut V);
     /// Recursively visit all nodes in the AST using a [`VisitorMut`].
-    fn walk_mut<'a, V: VisitorMut<'s, 'a>>(&'a mut self, visitor: &mut V);
+    fn walk_mut<'a, V: VisitorMut<'a>>(&'a mut self, visitor: &mut V);
     /// Compiles current node into a [`CompiledValueExpr`] using [`Compiler`].
-    fn compile_with_compiler<C: Compiler<'s> + 's>(
-        self,
-        compiler: &mut C,
-    ) -> CompiledValueExpr<'s, C::U>;
+    fn compile_with_compiler<C: Compiler>(self, compiler: &mut C) -> CompiledValueExpr<C::U>;
     /// Compiles current node into a [`CompiledValueExpr`] using [`DefaultCompiler`].
-    fn compile(self) -> CompiledValueExpr<'s> {
+    fn compile(self) -> CompiledValueExpr {
         let mut compiler = DefaultCompiler::new();
         self.compile_with_compiler(&mut compiler)
     }
@@ -66,20 +60,20 @@ pub trait ValueExpr<'s>:
 /// [`crate::ExecutionContext`] is created from the same scheme.
 #[derive(PartialEq, Eq, Serialize, Clone, Hash)]
 #[serde(transparent)]
-pub struct FilterAst<'s> {
+pub struct FilterAst {
     #[serde(skip)]
-    scheme: &'s Scheme,
+    scheme: Scheme,
 
-    op: LogicalExpr<'s>,
+    op: LogicalExpr,
 }
 
-impl Debug for FilterAst<'_> {
+impl Debug for FilterAst {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.op.fmt(f)
     }
 }
 
-impl<'i, 's> LexWith<'i, &FilterParser<'s>> for FilterAst<'s> {
+impl<'i, 's> LexWith<'i, &FilterParser<'s>> for FilterAst {
     fn lex_with(input: &'i str, parser: &FilterParser<'s>) -> LexResult<'i, Self> {
         let (op, input) = LogicalExpr::lex_with(input, parser)?;
         // LogicalExpr::lex_with can return an AST where the root is an
@@ -96,7 +90,7 @@ impl<'i, 's> LexWith<'i, &FilterParser<'s>> for FilterAst<'s> {
         match ty {
             Type::Bool => Ok((
                 FilterAst {
-                    scheme: parser.scheme,
+                    scheme: parser.scheme.clone(),
                     op,
                 },
                 input,
@@ -112,28 +106,28 @@ impl<'i, 's> LexWith<'i, &FilterParser<'s>> for FilterAst<'s> {
     }
 }
 
-impl<'s> FilterAst<'s> {
+impl FilterAst {
     /// Returns the associated scheme.
     #[inline]
-    pub fn scheme(&self) -> &'s Scheme {
-        self.scheme
+    pub fn scheme(&self) -> &Scheme {
+        &self.scheme
     }
 
     /// Returns the associated expression.
     #[inline]
-    pub fn expression(&self) -> &LogicalExpr<'s> {
+    pub fn expression(&self) -> &LogicalExpr {
         &self.op
     }
 
     /// Recursively visit all nodes in the AST using a [`Visitor`].
     #[inline]
-    pub fn walk<'a, V: Visitor<'s, 'a>>(&'a self, visitor: &mut V) {
+    pub fn walk<'a, V: Visitor<'a>>(&'a self, visitor: &mut V) {
         visitor.visit_logical_expr(&self.op)
     }
 
     /// Recursively visit all nodes in the AST using a [`VisitorMut`].
     #[inline]
-    pub fn walk_mut<'a, V: VisitorMut<'s, 'a>>(&'a mut self, visitor: &mut V) {
+    pub fn walk_mut<'a, V: VisitorMut<'a>>(&'a mut self, visitor: &mut V) {
         visitor.visit_logical_expr(&mut self.op)
     }
 
@@ -158,7 +152,7 @@ impl<'s> FilterAst<'s> {
     }
 
     /// Compiles a [`FilterAst`] into a [`Filter`] using a specific [`Compiler`].
-    pub fn compile_with_compiler<C: Compiler<'s> + 's>(self, compiler: &mut C) -> Filter<'s, C::U> {
+    pub fn compile_with_compiler<C: Compiler>(self, compiler: &mut C) -> Filter<C::U> {
         match compiler.compile_logical_expr(self.op) {
             CompiledExpr::One(one) => Filter::new(one, self.scheme),
             CompiledExpr::Vec(_) => unreachable!(),
@@ -166,7 +160,7 @@ impl<'s> FilterAst<'s> {
     }
 
     /// Compiles a [`FilterAst`] into a [`Filter`] using the [`DefaultCompiler`].
-    pub fn compile(self) -> Filter<'s> {
+    pub fn compile(self) -> Filter {
         let mut compiler = DefaultCompiler::new();
         self.compile_with_compiler(&mut compiler)
     }
@@ -179,20 +173,20 @@ impl<'s> FilterAst<'s> {
 /// [`crate::ExecutionContext`] is created from the same scheme.
 #[derive(PartialEq, Eq, Serialize, Clone, Hash)]
 #[serde(transparent)]
-pub struct FilterValueAst<'s> {
+pub struct FilterValueAst {
     #[serde(skip)]
-    scheme: &'s Scheme,
+    scheme: Scheme,
 
-    op: IndexExpr<'s>,
+    op: IndexExpr,
 }
 
-impl Debug for FilterValueAst<'_> {
+impl Debug for FilterValueAst {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.op.fmt(f)
     }
 }
 
-impl<'i, 's> LexWith<'i, &FilterParser<'s>> for FilterValueAst<'s> {
+impl<'i, 's> LexWith<'i, &FilterParser<'s>> for FilterValueAst {
     fn lex_with(input: &'i str, parser: &FilterParser<'s>) -> LexResult<'i, Self> {
         let (op, rest) = IndexExpr::lex_with(input.trim(), parser)?;
         if op.map_each_count() > 0 {
@@ -206,7 +200,7 @@ impl<'i, 's> LexWith<'i, &FilterParser<'s>> for FilterValueAst<'s> {
         } else {
             Ok((
                 FilterValueAst {
-                    scheme: parser.scheme(),
+                    scheme: parser.scheme().clone(),
                     op,
                 },
                 rest,
@@ -215,28 +209,28 @@ impl<'i, 's> LexWith<'i, &FilterParser<'s>> for FilterValueAst<'s> {
     }
 }
 
-impl<'s> FilterValueAst<'s> {
+impl FilterValueAst {
     /// Returns the associated scheme.
     #[inline]
-    pub fn scheme(&self) -> &'s Scheme {
-        self.scheme
+    pub fn scheme(&self) -> &Scheme {
+        &self.scheme
     }
 
     /// Returns the associated expression.
     #[inline]
-    pub fn expression(&self) -> &IndexExpr<'s> {
+    pub fn expression(&self) -> &IndexExpr {
         &self.op
     }
 
     /// Recursively visit all nodes in the AST using a [`Visitor`].
     #[inline]
-    pub fn walk<'a, V: Visitor<'s, 'a>>(&'a self, visitor: &mut V) {
+    pub fn walk<'a, V: Visitor<'a>>(&'a self, visitor: &mut V) {
         visitor.visit_index_expr(&self.op)
     }
 
     /// Recursively visit all nodes in the AST using a [`VisitorMut`].
     #[inline]
-    pub fn walk_mut<'a, V: VisitorMut<'s, 'a>>(&'a mut self, visitor: &mut V) {
+    pub fn walk_mut<'a, V: VisitorMut<'a>>(&'a mut self, visitor: &mut V) {
         visitor.visit_index_expr(&mut self.op)
     }
 
@@ -261,21 +255,18 @@ impl<'s> FilterValueAst<'s> {
     }
 
     /// Compiles a [`FilterValueAst`] into a [`FilterValue`] using a specific [`Compiler`].
-    pub fn compile_with_compiler<C: Compiler<'s> + 's>(
-        self,
-        compiler: &mut C,
-    ) -> FilterValue<'s, C::U> {
+    pub fn compile_with_compiler<C: Compiler>(self, compiler: &mut C) -> FilterValue<C::U> {
         FilterValue::new(compiler.compile_index_expr(self.op), self.scheme)
     }
 
     /// Compiles a [`FilterValueAst`] into a [`FilterValue`] using the [`DefaultCompiler`].
-    pub fn compile(self) -> FilterValue<'s> {
+    pub fn compile(self) -> FilterValue {
         let mut compiler = DefaultCompiler::new();
         self.compile_with_compiler(&mut compiler)
     }
 }
 
-impl GetType for FilterValueAst<'_> {
+impl GetType for FilterValueAst {
     #[inline]
     fn get_type(&self) -> Type {
         self.op.get_type()

--- a/engine/src/ast/parse.rs
+++ b/engine/src/ast/parse.rs
@@ -161,12 +161,12 @@ impl<'s> FilterParser<'s> {
     }
 
     /// Parses a filter expression into an AST form.
-    pub fn parse<'i>(&self, input: &'i str) -> Result<FilterAst<'s>, ParseError<'i>> {
+    pub fn parse<'i>(&self, input: &'i str) -> Result<FilterAst, ParseError<'i>> {
         complete(self.lex_as(input.trim())).map_err(|err| ParseError::new(input, err))
     }
 
     /// Parses a value expression into an AST form.
-    pub fn parse_value<'i>(&self, input: &'i str) -> Result<FilterValueAst<'s>, ParseError<'i>> {
+    pub fn parse_value<'i>(&self, input: &'i str) -> Result<FilterValueAst, ParseError<'i>> {
         complete(self.lex_as(input.trim())).map_err(|err| ParseError::new(input, err))
     }
 

--- a/engine/src/ast/visitor.rs
+++ b/engine/src/ast/visitor.rs
@@ -5,27 +5,27 @@ use super::{
     logical_expr::LogicalExpr,
     Expr, ValueExpr,
 };
-use crate::scheme::{Field, Function};
+use crate::{Field, FieldRef, Function};
 
 /// Trait used to immutably visit all nodes in the AST.
-pub trait Visitor<'s, 'a>: Sized {
+pub trait Visitor<'a>: Sized {
     // `Expr` node visitor methods
 
     /// Visit [`Expr`] node.
     #[inline]
-    fn visit_expr(&mut self, node: &'a impl Expr<'s>) {
+    fn visit_expr(&mut self, node: &'a impl Expr) {
         node.walk(self)
     }
 
     /// Visit [`LogicalExpr`] node.
     #[inline]
-    fn visit_logical_expr(&mut self, node: &'a LogicalExpr<'s>) {
+    fn visit_logical_expr(&mut self, node: &'a LogicalExpr) {
         self.visit_expr(node)
     }
 
     /// Visit [`ComparisonExpr`] node.
     #[inline]
-    fn visit_comparison_expr(&mut self, node: &'a ComparisonExpr<'s>) {
+    fn visit_comparison_expr(&mut self, node: &'a ComparisonExpr) {
         self.visit_expr(node)
     }
 
@@ -33,25 +33,25 @@ pub trait Visitor<'s, 'a>: Sized {
 
     /// Visit [`ValueExpr`] node.
     #[inline]
-    fn visit_value_expr(&mut self, node: &'a impl ValueExpr<'s>) {
+    fn visit_value_expr(&mut self, node: &'a impl ValueExpr) {
         node.walk(self)
     }
 
     /// Visit [`IndexExpr`] node.
     #[inline]
-    fn visit_index_expr(&mut self, node: &'a IndexExpr<'s>) {
+    fn visit_index_expr(&mut self, node: &'a IndexExpr) {
         self.visit_value_expr(node)
     }
 
     /// Visit [`FunctionCallExpr`] node.
     #[inline]
-    fn visit_function_call_expr(&mut self, node: &'a FunctionCallExpr<'s>) {
+    fn visit_function_call_expr(&mut self, node: &'a FunctionCallExpr) {
         self.visit_value_expr(node)
     }
 
     /// Visit [`FunctionCallArgExpr`] node.
     #[inline]
-    fn visit_function_call_arg_expr(&mut self, node: &'a FunctionCallArgExpr<'s>) {
+    fn visit_function_call_arg_expr(&mut self, node: &'a FunctionCallArgExpr) {
         self.visit_value_expr(node)
     }
 
@@ -59,11 +59,11 @@ pub trait Visitor<'s, 'a>: Sized {
 
     /// Visit [`Field`] node.
     #[inline]
-    fn visit_field(&mut self, _: &'a Field<'s>) {}
+    fn visit_field(&mut self, _: &'a Field) {}
 
     /// Visit [`Function`] node.
     #[inline]
-    fn visit_function(&mut self, _: &'a Function<'s>) {}
+    fn visit_function(&mut self, _: &'a Function) {}
 
     // TODO: add visitor methods for literals?
 }
@@ -73,24 +73,24 @@ pub trait Visitor<'s, 'a>: Sized {
 /// Note that this trait is dangerous and any modification
 /// to the AST should be done with cautions and respect
 /// some invariants such as keeping type coherency.
-pub trait VisitorMut<'s, 'a>: Sized {
+pub trait VisitorMut<'a>: Sized {
     // `Expr` node visitor methods
 
     /// Visit [`Expr`] node.
     #[inline]
-    fn visit_expr(&mut self, node: &'a mut impl Expr<'s>) {
+    fn visit_expr(&mut self, node: &'a mut impl Expr) {
         node.walk_mut(self)
     }
 
     /// Visit [`LogicalExpr`] node.
     #[inline]
-    fn visit_logical_expr(&mut self, node: &'a mut LogicalExpr<'s>) {
+    fn visit_logical_expr(&mut self, node: &'a mut LogicalExpr) {
         self.visit_expr(node)
     }
 
     /// Visit [`ComparisonExpr`] node.
     #[inline]
-    fn visit_comparison_expr(&mut self, node: &'a mut ComparisonExpr<'s>) {
+    fn visit_comparison_expr(&mut self, node: &'a mut ComparisonExpr) {
         self.visit_expr(node)
     }
 
@@ -98,25 +98,25 @@ pub trait VisitorMut<'s, 'a>: Sized {
 
     /// Visit [`ValueExpr`] node.
     #[inline]
-    fn visit_value_expr(&mut self, node: &'a mut impl ValueExpr<'s>) {
+    fn visit_value_expr(&mut self, node: &'a mut impl ValueExpr) {
         node.walk_mut(self)
     }
 
     /// Visit [`IndexExpr`] node.
     #[inline]
-    fn visit_index_expr(&mut self, node: &'a mut IndexExpr<'s>) {
+    fn visit_index_expr(&mut self, node: &'a mut IndexExpr) {
         self.visit_value_expr(node)
     }
 
     /// Visit [`FunctionCallExpr`] node.
     #[inline]
-    fn visit_function_call_expr(&mut self, node: &'a mut FunctionCallExpr<'s>) {
+    fn visit_function_call_expr(&mut self, node: &'a mut FunctionCallExpr) {
         self.visit_value_expr(node)
     }
 
     /// Visit [`FunctionCallArgExpr`] node.
     #[inline]
-    fn visit_function_call_arg_expr(&mut self, node: &'a mut FunctionCallArgExpr<'s>) {
+    fn visit_function_call_arg_expr(&mut self, node: &'a mut FunctionCallArgExpr) {
         self.visit_value_expr(node)
     }
 
@@ -124,23 +124,23 @@ pub trait VisitorMut<'s, 'a>: Sized {
 
     /// Visit [`Field`] node.
     #[inline]
-    fn visit_field(&mut self, _: &'a Field<'s>) {}
+    fn visit_field(&mut self, _: &'a Field) {}
 
     /// Visit [`Function`] node.
     #[inline]
-    fn visit_function(&mut self, _: &'a Function<'s>) {}
+    fn visit_function(&mut self, _: &'a Function) {}
 
     // TODO: add visitor methods for literals?
 }
 
 /// Recursively check if a [`Field`] is being used.
 pub(crate) struct UsesVisitor<'s> {
-    field: Field<'s>,
+    field: FieldRef<'s>,
     uses: bool,
 }
 
 impl<'s> UsesVisitor<'s> {
-    pub fn new(field: Field<'s>) -> Self {
+    pub fn new(field: FieldRef<'s>) -> Self {
         Self { field, uses: false }
     }
 
@@ -149,22 +149,22 @@ impl<'s> UsesVisitor<'s> {
     }
 }
 
-impl<'s> Visitor<'s, '_> for UsesVisitor<'s> {
-    fn visit_expr(&mut self, node: &impl Expr<'s>) {
+impl Visitor<'_> for UsesVisitor<'_> {
+    fn visit_expr(&mut self, node: &impl Expr) {
         // Stop visiting the AST once we have found one occurence of the field
         if !self.uses {
             node.walk(self)
         }
     }
 
-    fn visit_value_expr(&mut self, node: &impl ValueExpr<'s>) {
+    fn visit_value_expr(&mut self, node: &impl ValueExpr) {
         // Stop visiting the AST once we have found one occurence of the field
         if !self.uses {
             node.walk(self)
         }
     }
 
-    fn visit_field(&mut self, f: &Field<'s>) {
+    fn visit_field(&mut self, f: &Field) {
         if self.field == *f {
             self.uses = true;
         }
@@ -173,12 +173,12 @@ impl<'s> Visitor<'s, '_> for UsesVisitor<'s> {
 
 /// Recursively check if a [`Field`] is being used in a list comparison.
 pub(crate) struct UsesListVisitor<'s> {
-    field: Field<'s>,
+    field: FieldRef<'s>,
     uses: bool,
 }
 
 impl<'s> UsesListVisitor<'s> {
-    pub fn new(field: Field<'s>) -> Self {
+    pub fn new(field: FieldRef<'s>) -> Self {
         Self { field, uses: false }
     }
 
@@ -187,22 +187,22 @@ impl<'s> UsesListVisitor<'s> {
     }
 }
 
-impl<'s> Visitor<'s, '_> for UsesListVisitor<'s> {
-    fn visit_expr(&mut self, node: &impl Expr<'s>) {
+impl Visitor<'_> for UsesListVisitor<'_> {
+    fn visit_expr(&mut self, node: &impl Expr) {
         // Stop visiting the AST once we have found one occurence of the field
         if !self.uses {
             node.walk(self)
         }
     }
 
-    fn visit_value_expr(&mut self, node: &impl ValueExpr<'s>) {
+    fn visit_value_expr(&mut self, node: &impl ValueExpr) {
         // Stop visiting the AST once we have found one occurence of the field
         if !self.uses {
             node.walk(self)
         }
     }
 
-    fn visit_comparison_expr(&mut self, comparison_expr: &ComparisonExpr<'s>) {
+    fn visit_comparison_expr(&mut self, comparison_expr: &ComparisonExpr) {
         if let ComparisonOpExpr::InList { .. } = comparison_expr.op {
             let mut visitor = UsesVisitor::new(self.field);
             visitor.visit_comparison_expr(comparison_expr);

--- a/engine/src/compiler.rs
+++ b/engine/src/compiler.rs
@@ -4,40 +4,37 @@ use crate::{
 };
 
 /// Trait used to drive the compilation of a [`crate::FilterAst`] into a [`crate::Filter`].
-pub trait Compiler<'s>: Sized + 's {
+pub trait Compiler: Sized {
     /// The user data type passed in the  [`crate::ExecutionContext`].
-    type U;
+    type U: 'static;
 
     /// Compiles a [`Expr`] node into a [`CompiledExpr`] (boxed closure).
     #[inline]
-    fn compile_expr(&mut self, node: impl Expr<'s>) -> CompiledExpr<'s, Self::U> {
+    fn compile_expr(&mut self, node: impl Expr) -> CompiledExpr<Self::U> {
         node.compile_with_compiler(self)
     }
 
     /// Compiles a [`LogicalExpr`] node into a [`CompiledExpr`] (boxed closure).
     #[inline]
-    fn compile_logical_expr(&mut self, node: LogicalExpr<'s>) -> CompiledExpr<'s, Self::U> {
+    fn compile_logical_expr(&mut self, node: LogicalExpr) -> CompiledExpr<Self::U> {
         self.compile_expr(node)
     }
 
     /// Compiles a [`ComparisonExpr`] node into a [`CompiledExpr`] (boxed closure).
     #[inline]
-    fn compile_comparison_expr(&mut self, node: ComparisonExpr<'s>) -> CompiledExpr<'s, Self::U> {
+    fn compile_comparison_expr(&mut self, node: ComparisonExpr) -> CompiledExpr<Self::U> {
         self.compile_expr(node)
     }
 
     /// Compiles a [`ValueExpr`] node into a [`CompiledValueExpr`] (boxed closure).
     #[inline]
-    fn compile_value_expr(&mut self, node: impl ValueExpr<'s>) -> CompiledValueExpr<'s, Self::U> {
+    fn compile_value_expr(&mut self, node: impl ValueExpr) -> CompiledValueExpr<Self::U> {
         node.compile_with_compiler(self)
     }
 
     /// Compiles a [`FunctionCallExpr`] node into a [`CompiledValueExpr`] (boxed closure).
     #[inline]
-    fn compile_function_call_expr(
-        &mut self,
-        node: FunctionCallExpr<'s>,
-    ) -> CompiledValueExpr<'s, Self::U> {
+    fn compile_function_call_expr(&mut self, node: FunctionCallExpr) -> CompiledValueExpr<Self::U> {
         self.compile_value_expr(node)
     }
 
@@ -45,14 +42,14 @@ pub trait Compiler<'s>: Sized + 's {
     #[inline]
     fn compile_function_call_arg_expr(
         &mut self,
-        node: FunctionCallArgExpr<'s>,
-    ) -> CompiledValueExpr<'s, Self::U> {
+        node: FunctionCallArgExpr,
+    ) -> CompiledValueExpr<Self::U> {
         self.compile_value_expr(node)
     }
 
     /// Compiles a [`IndexExpr`] node into a [`CompiledValueExpr`] (boxed closure).
     #[inline]
-    fn compile_index_expr(&mut self, node: IndexExpr<'s>) -> CompiledValueExpr<'s, Self::U> {
+    fn compile_index_expr(&mut self, node: IndexExpr) -> CompiledValueExpr<Self::U> {
         self.compile_value_expr(node)
     }
 }
@@ -80,6 +77,6 @@ impl<U> DefaultCompiler<U> {
     }
 }
 
-impl<'s, U: 's> Compiler<'s> for DefaultCompiler<U> {
+impl<U: 'static> Compiler for DefaultCompiler<U> {
     type U = U;
 }

--- a/engine/src/functions/all.rs
+++ b/engine/src/functions/all.rs
@@ -62,7 +62,8 @@ impl FunctionDefinition for AllFunction {
         &'s self,
         _: &mut dyn ExactSizeIterator<Item = FunctionParam<'_>>,
         _: Option<FunctionDefinitionContext>,
-    ) -> Box<dyn for<'a> Fn(FunctionArgs<'_, 'a>) -> Option<LhsValue<'a>> + Sync + Send + 's> {
+    ) -> Box<dyn for<'i, 'a> Fn(FunctionArgs<'i, 'a>) -> Option<LhsValue<'a>> + Sync + Send + 'static>
+    {
         Box::new(all_impl)
     }
 }

--- a/engine/src/functions/any.rs
+++ b/engine/src/functions/any.rs
@@ -62,7 +62,8 @@ impl FunctionDefinition for AnyFunction {
         &'s self,
         _: &mut dyn ExactSizeIterator<Item = FunctionParam<'_>>,
         _: Option<FunctionDefinitionContext>,
-    ) -> Box<dyn for<'a> Fn(FunctionArgs<'_, 'a>) -> Option<LhsValue<'a>> + Sync + Send + 's> {
+    ) -> Box<dyn for<'i, 'a> Fn(FunctionArgs<'i, 'a>) -> Option<LhsValue<'a>> + Sync + Send + 'static>
+    {
         Box::new(any_impl)
     }
 }

--- a/engine/src/functions/concat.rs
+++ b/engine/src/functions/concat.rs
@@ -81,7 +81,8 @@ impl FunctionDefinition for ConcatFunction {
         &'s self,
         _: &mut dyn ExactSizeIterator<Item = FunctionParam<'_>>,
         _: Option<FunctionDefinitionContext>,
-    ) -> Box<dyn for<'a> Fn(FunctionArgs<'_, 'a>) -> Option<LhsValue<'a>> + Sync + Send + 's> {
+    ) -> Box<dyn for<'i, 'a> Fn(FunctionArgs<'i, 'a>) -> Option<LhsValue<'a>> + Sync + Send + 'static>
+    {
         Box::new(|args| {
             while let Some(arg) = args.next() {
                 match arg {

--- a/engine/src/functions/mod.rs
+++ b/engine/src/functions/mod.rs
@@ -396,11 +396,11 @@ pub trait FunctionDefinition: Debug + Send + Sync {
     fn arg_count(&self) -> (usize, Option<usize>);
     /// Compile the function definition down to a closure that is going to be called
     /// during filter execution.
-    fn compile<'s>(
-        &'s self,
+    fn compile(
+        &self,
         params: &mut dyn ExactSizeIterator<Item = FunctionParam<'_>>,
         ctx: Option<FunctionDefinitionContext>,
-    ) -> Box<dyn for<'i, 'a> Fn(FunctionArgs<'i, 'a>) -> Option<LhsValue<'a>> + Sync + Send + 's>;
+    ) -> Box<dyn for<'i, 'a> Fn(FunctionArgs<'i, 'a>) -> Option<LhsValue<'a>> + Sync + Send + 'static>;
 }
 
 /* Simple function APIs */
@@ -505,7 +505,7 @@ impl FunctionDefinition for SimpleFunctionDefinition {
         &self,
         params: &mut dyn ExactSizeIterator<Item = FunctionParam<'_>>,
         _: Option<FunctionDefinitionContext>,
-    ) -> Box<dyn for<'i, 'a> Fn(FunctionArgs<'i, 'a>) -> Option<LhsValue<'a>> + Sync + Send + '_>
+    ) -> Box<dyn for<'i, 'a> Fn(FunctionArgs<'i, 'a>) -> Option<LhsValue<'a>> + Sync + Send + 'static>
     {
         let params_count = params.len();
         let opt_params = &self.opt_params[(params_count - self.params.len())..];

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -115,9 +115,9 @@ pub use self::{
         RegexFormat,
     },
     scheme::{
-        Field, FieldIndex, FieldRedefinitionError, Function, FunctionRedefinitionError,
-        IdentifierRedefinitionError, IndexAccessError, List, Scheme, SchemeBuilder,
-        SchemeMismatchError, UnknownFieldError,
+        Field, FieldIndex, FieldRedefinitionError, FieldRef, Function, FunctionRedefinitionError,
+        FunctionRef, IdentifierRedefinitionError, IndexAccessError, List, ListRef, Scheme,
+        SchemeBuilder, SchemeMismatchError, UnknownFieldError,
     },
     types::{
         CompoundType, ExpectedType, ExpectedTypeList, GetType, LhsValue, LhsValueMut, RhsValue,


### PR DESCRIPTION
This allows to remove the `'s` lifetime in most of the codebase which should also simplify the life of wirefilter users.

It also enables downstream crates to implement deserialization of filter AST with serde using TLS stored scheme or similar tricks.