### PR TITLE
Introduce `SchemeBuilder` to build a `Scheme`

### DIFF
--- a/engine/benches/bench.rs
+++ b/engine/benches/bench.rs
@@ -8,7 +8,7 @@ static A: System = System;
 use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 use std::{borrow::Cow, clone::Clone, fmt::Debug, net::IpAddr};
 use wirefilter::{
-    ExecutionContext, FilterAst, FunctionArgKind, FunctionArgs, GetType, LhsValue, Scheme,
+    ExecutionContext, FilterAst, FunctionArgKind, FunctionArgs, GetType, LhsValue, SchemeBuilder,
     SimpleFunctionDefinition, SimpleFunctionImpl, SimpleFunctionParam, Type,
 };
 
@@ -79,11 +79,12 @@ impl<T: 'static + Copy + Debug + Into<LhsValue<'static>>> FieldBench<'_, T> {
             let mut group = c.benchmark_group("parsing");
 
             group.bench_function(name, {
-                let mut scheme = Scheme::default();
-                scheme.add_field(field, ty).unwrap();
+                let mut builder = SchemeBuilder::default();
+                builder.add_field(field, ty).unwrap();
                 for (name, function) in functions {
-                    scheme.add_function(name, function.clone()).unwrap();
+                    builder.add_function(name, function.clone()).unwrap();
                 }
+                let scheme = builder.build();
                 move |b: &mut Bencher| {
                     b.iter(|| scheme.parse(filter).unwrap());
                 }
@@ -94,11 +95,12 @@ impl<T: 'static + Copy + Debug + Into<LhsValue<'static>>> FieldBench<'_, T> {
             let mut group = c.benchmark_group("compilation");
 
             group.bench_function(name, {
-                let mut scheme = Scheme::default();
-                scheme.add_field(field, ty).unwrap();
+                let mut builder = SchemeBuilder::default();
+                builder.add_field(field, ty).unwrap();
                 for (name, function) in functions {
-                    scheme.add_function(name, function.clone()).unwrap();
+                    builder.add_function(name, function.clone()).unwrap();
                 }
+                let scheme = builder.build();
                 move |b: &mut Bencher| {
                     let filter = scheme.parse(filter).unwrap();
 
@@ -111,11 +113,12 @@ impl<T: 'static + Copy + Debug + Into<LhsValue<'static>>> FieldBench<'_, T> {
             let mut group = c.benchmark_group("execution");
 
             group.bench_with_input(name, values, {
-                let mut scheme = Scheme::default();
-                scheme.add_field(field, ty).unwrap();
+                let mut builder = SchemeBuilder::default();
+                builder.add_field(field, ty).unwrap();
                 for (name, function) in functions {
-                    scheme.add_function(name, function.clone()).unwrap();
+                    builder.add_function(name, function.clone()).unwrap();
                 }
+                let scheme = builder.build();
                 move |b: &mut Bencher, values: &[T]| {
                     let filter = scheme.parse(filter).unwrap();
 

--- a/engine/examples/cli.rs
+++ b/engine/examples/cli.rs
@@ -13,7 +13,7 @@ fn main() {
         .nth(1)
         .expect("Expected an input as a command-line argument");
 
-    let mut scheme = Scheme! {
+    let mut builder = Scheme! {
         ip: Ip,
         str: Bytes,
         int: Int,
@@ -23,7 +23,7 @@ fn main() {
         bool_arr: Array(Bool),
     };
 
-    scheme
+    builder
         .add_function(
             "panic",
             SimpleFunctionDefinition {
@@ -40,6 +40,8 @@ fn main() {
             },
         )
         .unwrap();
+
+    let scheme = builder.build();
 
     match scheme.parse(&filter) {
         Ok(res) => println!("{res:#?}"),

--- a/engine/src/ast/field_expr.rs
+++ b/engine/src/ast/field_expr.rs
@@ -805,7 +805,7 @@ mod tests {
     }
 
     static SCHEME: LazyLock<Scheme> = LazyLock::new(|| {
-        let mut scheme: Scheme = Scheme! {
+        let mut builder = Scheme! {
             http.cookies: Array(Bytes),
             http.headers: Map(Bytes),
             http.host: Bytes,
@@ -816,7 +816,7 @@ mod tests {
             array.of.bool: Array(Bool),
             http.parts: Array(Array(Bytes)),
         };
-        scheme
+        builder
             .add_function(
                 "any",
                 SimpleFunctionDefinition {
@@ -830,7 +830,7 @@ mod tests {
                 },
             )
             .unwrap();
-        scheme
+        builder
             .add_function(
                 "echo",
                 SimpleFunctionDefinition {
@@ -844,7 +844,7 @@ mod tests {
                 },
             )
             .unwrap();
-        scheme
+        builder
             .add_function(
                 "lowercase",
                 SimpleFunctionDefinition {
@@ -858,7 +858,7 @@ mod tests {
                 },
             )
             .unwrap();
-        scheme
+        builder
             .add_function(
                 "concat",
                 SimpleFunctionDefinition {
@@ -878,10 +878,10 @@ mod tests {
                 },
             )
             .unwrap();
-        scheme
+        builder
             .add_function("filter", FilterFunction::new())
             .unwrap();
-        scheme
+        builder
             .add_function(
                 "len",
                 SimpleFunctionDefinition {
@@ -895,10 +895,10 @@ mod tests {
                 },
             )
             .unwrap();
-        scheme
+        builder
             .add_list(Type::Int, Box::new(NumMListDefinition {}))
             .unwrap();
-        scheme
+        builder.build()
     });
 
     fn field(name: &'static str) -> Field<'static> {

--- a/engine/src/ast/function_expr.rs
+++ b/engine/src/ast/function_expr.rs
@@ -592,7 +592,7 @@ mod tests {
     }
 
     static SCHEME: LazyLock<Scheme> = LazyLock::new(|| {
-        let mut scheme = Scheme! {
+        let mut builder = Scheme! {
             http.headers: Map(Bytes),
             http.host: Bytes,
             http.request.headers.names: Array(Bytes),
@@ -602,7 +602,7 @@ mod tests {
             ssl: Bool,
             tcp.port: Int,
         };
-        scheme
+        builder
             .add_function(
                 "any",
                 SimpleFunctionDefinition {
@@ -616,7 +616,7 @@ mod tests {
                 },
             )
             .unwrap();
-        scheme
+        builder
             .add_function(
                 "echo",
                 SimpleFunctionDefinition {
@@ -639,7 +639,7 @@ mod tests {
                 },
             )
             .unwrap();
-        scheme
+        builder
             .add_function(
                 "lower",
                 SimpleFunctionDefinition {
@@ -653,7 +653,7 @@ mod tests {
                 },
             )
             .unwrap();
-        scheme
+        builder
             .add_function(
                 "regex_replace",
                 SimpleFunctionDefinition {
@@ -677,7 +677,7 @@ mod tests {
                 },
             )
             .unwrap();
-        scheme
+        builder
             .add_function(
                 "len",
                 SimpleFunctionDefinition {
@@ -691,7 +691,7 @@ mod tests {
                 },
             )
             .unwrap();
-        scheme
+        builder.build()
     });
 
     #[test]

--- a/engine/src/ast/index_expr.rs
+++ b/engine/src/ast/index_expr.rs
@@ -548,8 +548,8 @@ mod tests {
     use super::*;
     use crate::{
         ast::field_expr::IdentifierExpr, Array, FieldIndex, FilterParser, FunctionArgKind,
-        FunctionArgs, FunctionCallArgExpr, FunctionCallExpr, Scheme, SimpleFunctionDefinition,
-        SimpleFunctionImpl, SimpleFunctionParam,
+        FunctionArgs, FunctionCallArgExpr, FunctionCallExpr, Scheme, SchemeBuilder,
+        SimpleFunctionDefinition, SimpleFunctionImpl, SimpleFunctionParam,
     };
     use std::sync::LazyLock;
 
@@ -574,17 +574,17 @@ mod tests {
     }
 
     static SCHEME: LazyLock<Scheme> = LazyLock::new(|| {
-        let mut scheme = Scheme::new();
-        scheme
+        let mut builder = SchemeBuilder::new();
+        builder
             .add_field("test", Type::Array(Type::Bytes.into()))
             .unwrap();
-        scheme
+        builder
             .add_field("test2", Type::Array(Type::Array(Type::Bytes.into()).into()))
             .unwrap();
-        scheme
+        builder
             .add_field("map", Type::Map(Type::Bytes.into()))
             .unwrap();
-        scheme
+        builder
             .add_function(
                 "array",
                 SimpleFunctionDefinition {
@@ -598,7 +598,7 @@ mod tests {
                 },
             )
             .unwrap();
-        scheme
+        builder
             .add_function(
                 "array2",
                 SimpleFunctionDefinition {
@@ -612,7 +612,7 @@ mod tests {
                 },
             )
             .unwrap();
-        scheme
+        builder.build()
     });
 
     #[test]

--- a/engine/src/ast/logical_expr.rs
+++ b/engine/src/ast/logical_expr.rs
@@ -345,7 +345,8 @@ fn test() {
         at: Array(Bool),
         af: Array(Bool),
         aat: Array(Array(Bool)),
-    };
+    }
+    .build();
 
     let ctx = &mut ExecutionContext::new(scheme);
 

--- a/engine/src/ast/visitor.rs
+++ b/engine/src/ast/visitor.rs
@@ -225,7 +225,7 @@ mod tests {
     use std::sync::LazyLock;
 
     static SCHEME: LazyLock<Scheme> = LazyLock::new(|| {
-        let mut scheme = Scheme! {
+        let mut builder = Scheme! {
             http.headers: Map(Bytes),
             http.request.headers.names: Array(Bytes),
             http.request.headers.values: Array(Bytes),
@@ -234,7 +234,7 @@ mod tests {
             ssl: Bool,
             tcp.port: Int,
         };
-        scheme
+        builder
             .add_function(
                 "echo",
                 SimpleFunctionDefinition {
@@ -248,10 +248,10 @@ mod tests {
                 },
             )
             .unwrap();
-        scheme
+        builder
             .add_list(Type::Bytes, Box::new(AlwaysList {}))
             .unwrap();
-        scheme
+        builder.build()
     });
 
     #[test]

--- a/engine/src/execution_context.rs
+++ b/engine/src/execution_context.rs
@@ -355,7 +355,7 @@ impl Serialize for ExecutionContext<'_> {
 fn test_field_value_type_mismatch() {
     use crate::types::Type;
 
-    let scheme = Scheme! { foo: Int };
+    let scheme = Scheme! { foo: Int }.build();
 
     let mut ctx = ExecutionContext::<()>::new(&scheme);
 
@@ -370,11 +370,11 @@ fn test_field_value_type_mismatch() {
 
 #[test]
 fn test_scheme_mismatch() {
-    let scheme = Scheme! { foo: Bool };
+    let scheme = Scheme! { foo: Bool }.build();
 
     let mut ctx = ExecutionContext::<()>::new(&scheme);
 
-    let scheme2 = Scheme! { foo: Bool };
+    let scheme2 = Scheme! { foo: Bool }.build();
 
     assert_eq!(
         ctx.set_field_value(scheme2.get_field("foo").unwrap(), LhsValue::Bool(false)),
@@ -391,20 +391,18 @@ fn test_serde() {
     use std::net::IpAddr;
     use std::str::FromStr;
 
-    let mut scheme = Scheme::new();
-    scheme.add_field("bool", Type::Bool).unwrap();
-    scheme.add_field("ip", Type::Ip).unwrap();
-    scheme.add_field("str", Type::Bytes).unwrap();
-    scheme.add_field("bytes", Type::Bytes).unwrap();
-    scheme.add_field("num", Type::Int).unwrap();
-    scheme.add_field("min_num", Type::Int).unwrap();
-    scheme.add_field("max_num", Type::Int).unwrap();
-    scheme
-        .add_field("arr", Type::Array(Type::Bool.into()))
-        .unwrap();
-    scheme
-        .add_field("map", Type::Map(Type::Int.into()))
-        .unwrap();
+    let scheme = Scheme! {
+        bool: Bool,
+        ip: Ip,
+        str: Bytes,
+        bytes: Bytes,
+        num: Int,
+        min_num: Int,
+        max_num: Int,
+        arr: Array(Bool),
+        map: Map(Int),
+    }
+    .build();
 
     let mut ctx = ExecutionContext::new(&scheme);
 
@@ -550,13 +548,14 @@ fn test_serde() {
 
 #[test]
 fn test_clear() {
-    use crate::types::Type;
     use std::net::IpAddr;
     use std::str::FromStr;
 
-    let mut scheme = Scheme::new();
-    scheme.add_field("bool", Type::Bool).unwrap();
-    scheme.add_field("ip", Type::Ip).unwrap();
+    let scheme = Scheme! {
+        bool: Bool,
+        ip: Ip,
+    }
+    .build();
 
     let bool_field = scheme.get_field("bool").unwrap();
     let ip_field = scheme.get_field("ip").unwrap();

--- a/engine/src/filter.rs
+++ b/engine/src/filter.rs
@@ -244,8 +244,8 @@ mod tests {
 
     #[test]
     fn test_scheme_mismatch() {
-        let scheme1 = Scheme! { foo: Int };
-        let scheme2 = Scheme! { foo: Int, bar: Int };
+        let scheme1 = Scheme! { foo: Int }.build();
+        let scheme2 = Scheme! { foo: Int, bar: Int }.build();
         let filter = scheme1.parse("foo == 42").unwrap().compile();
         let ctx = ExecutionContext::new(&scheme2);
 

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -14,7 +14,7 @@
 //!         http.method: Bytes,
 //!         http.ua: Bytes,
 //!         port: Int,
-//!     };
+//!     }.build();
 //!
 //!     // Parse a Wireshark-like expression into an AST.
 //!     let ast = scheme.parse(
@@ -116,8 +116,8 @@ pub use self::{
     },
     scheme::{
         Field, FieldIndex, FieldRedefinitionError, Function, FunctionRedefinitionError, Identifier,
-        IdentifierRedefinitionError, IndexAccessError, List, Scheme, SchemeMismatchError,
-        UnknownFieldError,
+        IdentifierRedefinitionError, IndexAccessError, List, Scheme, SchemeBuilder,
+        SchemeMismatchError, UnknownFieldError,
     },
     types::{
         CompoundType, ExpectedType, ExpectedTypeList, GetType, LhsValue, LhsValueMut, RhsValue,

--- a/engine/src/rhs_types/regex/mod.rs
+++ b/engine/src/rhs_types/regex/mod.rs
@@ -149,11 +149,11 @@ pub enum Error {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{ParserSettings, Scheme};
+    use crate::{ParserSettings, SchemeBuilder};
 
     #[test]
     fn test() {
-        let scheme = Scheme::new();
+        let scheme = SchemeBuilder::new().build();
         let parser = FilterParser::new(&scheme);
 
         let expr = assert_ok!(
@@ -178,7 +178,7 @@ mod test {
 
     #[test]
     fn test_raw_string() {
-        let scheme = Scheme::new();
+        let scheme = SchemeBuilder::new().build();
         let parser = FilterParser::new(&scheme);
 
         let expr = assert_ok!(

--- a/engine/src/rhs_types/wildcard.rs
+++ b/engine/src/rhs_types/wildcard.rs
@@ -137,7 +137,7 @@ impl<'i, 's, const STRICT: bool> LexWith<'i, &FilterParser<'s>> for Wildcard<STR
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{BytesFormat, Scheme};
+    use crate::{BytesFormat, SchemeBuilder};
 
     #[test]
     fn test_wildcard_eq() {
@@ -178,7 +178,7 @@ mod test {
     #[test]
     fn test_wildcard_lex_quoted_string() {
         fn t<const STRICT: bool>() {
-            let scheme = Scheme::new();
+            let scheme = SchemeBuilder::new().build();
 
             let expr = assert_ok!(
                 Wildcard::<STRICT>::lex_with(r#""a quoted string";"#, &FilterParser::new(&scheme)),
@@ -206,7 +206,7 @@ mod test {
     #[test]
     fn test_wildcard_lex_raw_string() {
         fn t<const STRICT: bool>() {
-            let scheme = Scheme::new();
+            let scheme = SchemeBuilder::new().build();
 
             // Note that the `\\xaa` is escaping the `\` at the wildcard-language level, not at the
             // wirefilter-language level.
@@ -243,7 +243,7 @@ mod test {
     #[test]
     fn test_wildcard_lex_escape_quoted_string_invalid_utf8() {
         fn t<const STRICT: bool>() {
-            let scheme = Scheme::new();
+            let scheme = SchemeBuilder::new().build();
 
             let bytes = [
                 "a quoted ".as_bytes().to_vec(),
@@ -281,7 +281,7 @@ mod test {
     #[test]
     fn test_wildcard_lex_reject_bytes_syntax() {
         fn t<const STRICT: bool>() {
-            let scheme = Scheme::new();
+            let scheme = SchemeBuilder::new().build();
 
             assert_err!(
                 Wildcard::<STRICT>::lex_with("61:20:71:75:6F:74", &FilterParser::new(&scheme)),
@@ -297,7 +297,7 @@ mod test {
     #[test]
     fn test_wildcard_reject_invalid_wildcard() {
         fn t<const STRICT: bool>() {
-            let scheme = Scheme::new();
+            let scheme = SchemeBuilder::new().build();
 
             assert!(matches!(
                 Wildcard::<STRICT>::lex_with(r#"r"*foo\bar*""#, &FilterParser::new(&scheme))
@@ -315,7 +315,7 @@ mod test {
     #[test]
     fn test_wildcard_star_limit() {
         fn t<const STRICT: bool>() {
-            let scheme = Scheme::new();
+            let scheme = SchemeBuilder::new().build();
             let mut parser = FilterParser::new(&scheme);
 
             parser.wildcard_set_star_limit(3);
@@ -337,7 +337,7 @@ mod test {
     #[test]
     fn test_wildcard_reject_double_star() {
         fn t<const STRICT: bool>() {
-            let scheme = Scheme::new();
+            let scheme = SchemeBuilder::new().build();
 
             assert!(
                 Wildcard::<STRICT>::lex_with("\"*foo*bar*\"", &FilterParser::new(&scheme)).is_ok()

--- a/ffi/cbindgen.toml
+++ b/ffi/cbindgen.toml
@@ -32,6 +32,7 @@ renaming_overrides_prefixing = false
 "ParsingResult" = "parsing_result"
 "RustAllocatedString" = "rust_allocated_str"
 "Scheme" = "scheme"
+"SchemeBuilder" = "scheme_builder"
 "SerializingResult" = "serializing_result"
 "StaticRustAllocatedString" = "static_rust_allocated_str"
 "Status" = "status"

--- a/ffi/include/wirefilter.h
+++ b/ffi/include/wirefilter.h
@@ -61,6 +61,8 @@ struct wirefilter_map;
 
 struct wirefilter_scheme;
 
+struct wirefilter_scheme_builder;
+
 struct wirefilter_type {
   uint32_t layers;
   uint8_t len;
@@ -124,9 +126,9 @@ const char *wirefilter_get_last_error(void);
  */
 void wirefilter_clear_last_error(void);
 
-struct wirefilter_scheme *wirefilter_create_scheme(void);
+struct wirefilter_scheme_builder *wirefilter_create_scheme_builder(void);
 
-void wirefilter_free_scheme(struct wirefilter_scheme *scheme);
+void wirefilter_free_scheme_builder(struct wirefilter_scheme_builder *scheme);
 
 struct wirefilter_type wirefilter_create_primitive_type(wirefilter_primitive_type ty);
 
@@ -134,7 +136,7 @@ struct wirefilter_type wirefilter_create_map_type(struct wirefilter_type ty);
 
 struct wirefilter_type wirefilter_create_array_type(struct wirefilter_type ty);
 
-bool wirefilter_add_type_field_to_scheme(struct wirefilter_scheme *scheme,
+bool wirefilter_add_type_field_to_scheme(struct wirefilter_scheme_builder *builder,
                                          const char *name_ptr,
                                          size_t name_len,
                                          struct wirefilter_type ty);
@@ -143,9 +145,13 @@ struct wirefilter_list_definition *wirefilter_create_always_list(void);
 
 struct wirefilter_list_definition *wirefilter_create_never_list(void);
 
-bool wirefilter_add_type_list_to_scheme(struct wirefilter_scheme *scheme,
+bool wirefilter_add_type_list_to_scheme(struct wirefilter_scheme_builder *builder,
                                         struct wirefilter_type ty,
                                         struct wirefilter_list_definition *list);
+
+struct wirefilter_scheme *wirefilter_build_scheme(struct wirefilter_scheme_builder *builder);
+
+void wirefilter_free_scheme(struct wirefilter_scheme *scheme);
 
 void wirefilter_free_string(struct wirefilter_rust_allocated_str s);
 

--- a/ffi/tests/ctests/src/lib.rs
+++ b/ffi/tests/ctests/src/lib.rs
@@ -33,7 +33,7 @@ mod ffi_ctest {
         create_array_type,
         create_map_type,
         create_complex_type,
-        create_scheme,
+        create_scheme_builder,
         add_fields_to_scheme,
         add_malloced_type_field_to_scheme,
         parse_good_filter,


### PR DESCRIPTION
This makes the scheme immutable and allows to tailor its internals for parsing and execution of filter expressions.

Extracted from https://github.com/cloudflare/wirefilter/pull/119