### PR TITLE
Make `Array` and `Map` immutable

### DIFF
--- a/engine/src/ast/field_expr.rs
+++ b/engine/src/ast/field_expr.rs
@@ -788,7 +788,7 @@ impl Expr for ComparisonExpr {
 mod tests {
     use super::*;
     use crate::{
-        BytesFormat, FieldRef, LhsValue, ParserSettings,
+        BytesFormat, FieldRef, LhsValue, ParserSettings, TypedMap,
         ast::{
             function_expr::{FunctionCallArgExpr, FunctionCallExpr},
             logical_expr::LogicalExpr,
@@ -1586,18 +1586,18 @@ mod tests {
         let expr = expr.compile();
         let ctx = &mut ExecutionContext::new(&SCHEME);
 
-        let headers = LhsValue::Map({
-            let mut map = Map::new(Type::Bytes);
-            map.insert(b"host", "example.org").unwrap();
+        let headers = LhsValue::from({
+            let mut map = TypedMap::new();
+            map.insert(b"host".to_vec().into(), "example.org");
             map
         });
 
         ctx.set_field_value(field("http.headers"), headers).unwrap();
         assert_eq!(expr.execute_one(ctx), false);
 
-        let headers = LhsValue::Map({
-            let mut map = Map::new(Type::Bytes);
-            map.insert(b"host", "abc.net.au").unwrap();
+        let headers = LhsValue::from({
+            let mut map = TypedMap::new();
+            map.insert(b"host".to_vec().into(), "abc.net.au");
             map
         });
 
@@ -2186,11 +2186,11 @@ mod tests {
         let expr = expr.compile();
         let ctx = &mut ExecutionContext::new(&SCHEME);
 
-        let headers = LhsValue::Map({
-            let mut map = Map::new(Type::Bytes);
-            map.insert(b"0", "one").unwrap();
-            map.insert(b"1", "two").unwrap();
-            map.insert(b"2", "three").unwrap();
+        let headers = LhsValue::from({
+            let mut map = TypedMap::new();
+            map.insert(b"0".to_vec().into(), "one");
+            map.insert(b"1".to_vec().into(), "two");
+            map.insert(b"2".to_vec().into(), "three");
             map
         });
         ctx.set_field_value(field("http.headers"), headers).unwrap();
@@ -2267,11 +2267,11 @@ mod tests {
         let expr = expr.compile();
         let ctx = &mut ExecutionContext::new(&SCHEME);
 
-        let headers = LhsValue::Map({
-            let mut map = Map::new(Type::Bytes);
-            map.insert(b"0", "one").unwrap();
-            map.insert(b"1", "two").unwrap();
-            map.insert(b"2", "three").unwrap();
+        let headers = LhsValue::from({
+            let mut map = TypedMap::new();
+            map.insert(b"0".to_vec().into(), "one");
+            map.insert(b"1".to_vec().into(), "two");
+            map.insert(b"2".to_vec().into(), "three");
             map
         });
         ctx.set_field_value(field("http.headers"), headers).unwrap();

--- a/engine/src/execution_context.rs
+++ b/engine/src/execution_context.rs
@@ -425,8 +425,7 @@ fn test_scheme_mismatch() {
 
 #[test]
 fn test_serde() {
-    use crate::lhs_types::{Array, Map};
-    use crate::types::Type;
+    use crate::lhs_types::{Array, TypedMap};
     use std::net::IpAddr;
     use std::str::FromStr;
 
@@ -491,9 +490,9 @@ fn test_serde() {
 
     assert_eq!(
         ctx.set_field_value(scheme.get_field("map").unwrap(), {
-            let mut map = Map::new(Type::Int);
-            map.insert(b"leet", 1337).unwrap();
-            map.insert(b"tabs", 25).unwrap();
+            let mut map = TypedMap::<i64>::new();
+            map.insert(b"leet".to_vec().into(), 1337);
+            map.insert(b"tabs".to_vec().into(), 25);
             map
         }),
         Ok(None),
@@ -535,16 +534,16 @@ fn test_serde() {
 
     assert_eq!(
         ctx.set_field_value(scheme.get_field("map").unwrap(), {
-            let mut map = Map::new(Type::Int);
-            map.insert(b"leet", 1337).unwrap();
-            map.insert(b"tabs", 25).unwrap();
-            map.insert(b"a\xFF\xFFb", 17).unwrap();
+            let mut map = TypedMap::<i64>::new();
+            map.insert(b"leet".to_vec().into(), 1337);
+            map.insert(b"tabs".to_vec().into(), 25);
+            map.insert(b"a\xFF\xFFb".to_vec().into(), 17);
             map
         }),
         Ok(Some({
-            let mut map = Map::new(Type::Int);
-            map.insert(b"leet", 1337).unwrap();
-            map.insert(b"tabs", 25).unwrap();
+            let mut map = TypedMap::<i64>::new();
+            map.insert(b"leet".to_vec().into(), 1337);
+            map.insert(b"tabs".to_vec().into(), 25);
             map.into()
         })),
     );

--- a/engine/src/lhs_types/mod.rs
+++ b/engine/src/lhs_types/mod.rs
@@ -4,8 +4,8 @@ mod map;
 use crate::types::LhsValue;
 
 pub use self::{
-    array::{Array, ArrayIterator, ArrayMut, TypedArray},
-    map::{Map, MapIter, MapMut, MapValuesIntoIter, TypedMap},
+    array::{Array, ArrayIterator, TypedArray},
+    map::{Map, MapIter, MapValuesIntoIter, TypedMap},
 };
 
 pub struct AsRefIterator<'a, T: Iterator<Item = &'a LhsValue<'a>>>(T);

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -102,7 +102,7 @@ pub use self::{
         SimpleFunctionOptParam, SimpleFunctionParam,
     },
     lex::LexErrorKind,
-    lhs_types::{Array, ArrayMut, Map, MapIter, MapMut, TypedArray, TypedMap},
+    lhs_types::{Array, Map, MapIter, TypedArray, TypedMap},
     list_matcher::{
         AlwaysList, AlwaysListMatcher, ListDefinition, ListMatcher, NeverList, NeverListMatcher,
     },
@@ -120,7 +120,7 @@ pub use self::{
         SchemeBuilder, SchemeMismatchError, UnknownFieldError,
     },
     types::{
-        CompoundType, ExpectedType, ExpectedTypeList, GetType, LhsValue, LhsValueMut, RhsValue,
-        RhsValues, Type, TypeMismatchError,
+        CompoundType, ExpectedType, ExpectedTypeList, GetType, LhsValue, RhsValue, RhsValues, Type,
+        TypeMismatchError,
     },
 };

--- a/ffi/include/wirefilter.h
+++ b/ffi/include/wirefilter.h
@@ -47,15 +47,11 @@ enum wirefilter_status {
   WIREFILTER_STATUS_PANIC,
 };
 
-struct wirefilter_array;
-
 struct wirefilter_execution_context;
 
 struct wirefilter_filter;
 
 struct wirefilter_filter_ast;
-
-struct wirefilter_map;
 
 struct wirefilter_scheme;
 
@@ -175,6 +171,12 @@ bool wirefilter_deserialize_json_to_execution_context(struct wirefilter_executio
 
 void wirefilter_free_execution_context(struct wirefilter_execution_context *exec_context);
 
+bool wirefilter_add_json_value_to_execution_context(struct wirefilter_execution_context *exec_context,
+                                                    const char *name_ptr,
+                                                    size_t name_len,
+                                                    const uint8_t *json_ptr,
+                                                    size_t json_len);
+
 bool wirefilter_add_int_value_to_execution_context(struct wirefilter_execution_context *exec_context,
                                                    const char *name_ptr,
                                                    size_t name_len,
@@ -200,87 +202,6 @@ bool wirefilter_add_bool_value_to_execution_context(struct wirefilter_execution_
                                                     const char *name_ptr,
                                                     size_t name_len,
                                                     bool value);
-
-bool wirefilter_add_map_value_to_execution_context(struct wirefilter_execution_context *exec_context,
-                                                   const char *name_ptr,
-                                                   size_t name_len,
-                                                   struct wirefilter_map *value);
-
-bool wirefilter_add_array_value_to_execution_context(struct wirefilter_execution_context *exec_context,
-                                                     const char *name_ptr,
-                                                     size_t name_len,
-                                                     struct wirefilter_array *value);
-
-struct wirefilter_map *wirefilter_create_map(struct wirefilter_type ty);
-
-bool wirefilter_add_int_value_to_map(struct wirefilter_map *map,
-                                     const uint8_t *name_ptr,
-                                     size_t name_len,
-                                     int64_t value);
-
-bool wirefilter_add_bytes_value_to_map(struct wirefilter_map *map,
-                                       const uint8_t *name_ptr,
-                                       size_t name_len,
-                                       const uint8_t *value_ptr,
-                                       size_t value_len);
-
-bool wirefilter_add_ipv6_value_to_map(struct wirefilter_map *map,
-                                      const uint8_t *name_ptr,
-                                      size_t name_len,
-                                      const uint8_t (*value)[16]);
-
-bool wirefilter_add_ipv4_value_to_map(struct wirefilter_map *map,
-                                      const uint8_t *name_ptr,
-                                      size_t name_len,
-                                      const uint8_t (*value)[4]);
-
-bool wirefilter_add_bool_value_to_map(struct wirefilter_map *map,
-                                      const uint8_t *name_ptr,
-                                      size_t name_len,
-                                      bool value);
-
-bool wirefilter_add_map_value_to_map(struct wirefilter_map *map,
-                                     const uint8_t *name_ptr,
-                                     size_t name_len,
-                                     struct wirefilter_map *value);
-
-bool wirefilter_add_array_value_to_map(struct wirefilter_map *map,
-                                       const uint8_t *name_ptr,
-                                       size_t name_len,
-                                       struct wirefilter_array *value);
-
-void wirefilter_free_map(struct wirefilter_map *map);
-
-struct wirefilter_array *wirefilter_create_array(struct wirefilter_type ty);
-
-bool wirefilter_add_int_value_to_array(struct wirefilter_array *array,
-                                       uint32_t index,
-                                       int64_t value);
-
-bool wirefilter_add_bytes_value_to_array(struct wirefilter_array *array,
-                                         uint32_t index,
-                                         const uint8_t *value_ptr,
-                                         size_t value_len);
-
-bool wirefilter_add_ipv6_value_to_array(struct wirefilter_array *array,
-                                        uint32_t index,
-                                        const uint8_t (*value)[16]);
-
-bool wirefilter_add_ipv4_value_to_array(struct wirefilter_array *array,
-                                        uint32_t index,
-                                        const uint8_t (*value)[4]);
-
-bool wirefilter_add_bool_value_to_array(struct wirefilter_array *array, uint32_t index, bool value);
-
-bool wirefilter_add_map_value_to_array(struct wirefilter_array *array,
-                                       uint32_t index,
-                                       struct wirefilter_map *value);
-
-bool wirefilter_add_array_value_to_array(struct wirefilter_array *array,
-                                         uint32_t index,
-                                         struct wirefilter_array *value);
-
-void wirefilter_free_array(struct wirefilter_array *array);
 
 struct wirefilter_compiling_result wirefilter_compile_filter(struct wirefilter_filter_ast *filter_ast);
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -17,7 +17,7 @@ use std::{
     io::{self, Write},
     net::IpAddr,
 };
-use wirefilter::{AlwaysList, LhsValue, NeverList, Type, catch_panic};
+use wirefilter::{AlwaysList, GetType, NeverList, Type, catch_panic};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -191,30 +191,6 @@ wrap_type!(Scheme);
 pub struct ExecutionContext<'s>(wirefilter::ExecutionContext<'s>);
 
 wrap_type!(ExecutionContext<'s>);
-
-#[derive(Debug, PartialEq)]
-#[repr(Rust)]
-pub struct Array<'s>(wirefilter::Array<'s>);
-
-wrap_type!(Array<'s>);
-
-impl<'s> From<Array<'s>> for LhsValue<'s> {
-    fn from(array: Array<'s>) -> Self {
-        Self::Array(array.into())
-    }
-}
-
-#[derive(Debug, PartialEq)]
-#[repr(Rust)]
-pub struct Map<'s>(wirefilter::Map<'s>);
-
-wrap_type!(Map<'s>);
-
-impl<'s> From<Map<'s>> for LhsValue<'s> {
-    fn from(map: Map<'s>) -> Self {
-        Self::Map(map.into())
-    }
-}
 
 #[derive(Debug, PartialEq)]
 #[repr(Rust)]
@@ -548,7 +524,7 @@ pub extern "C" fn wirefilter_deserialize_json_to_execution_context(
 ) -> bool {
     assert!(!json_ptr.is_null());
     let json = unsafe { std::slice::from_raw_parts(json_ptr, json_len) };
-    let mut deserializer = serde_json::Deserializer::from_slice(json);
+    let mut deserializer = serde_json::Deserializer::from_reader(json);
     match exec_context.deserialize(&mut deserializer) {
         Ok(_) => true,
         Err(err) => {
@@ -561,6 +537,39 @@ pub extern "C" fn wirefilter_deserialize_json_to_execution_context(
 #[unsafe(no_mangle)]
 pub extern "C" fn wirefilter_free_execution_context(exec_context: Box<ExecutionContext<'_>>) {
     drop(exec_context);
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn wirefilter_add_json_value_to_execution_context(
+    exec_context: &mut ExecutionContext<'_>,
+    name_ptr: *const c_char,
+    name_len: usize,
+    json_ptr: *const u8,
+    json_len: usize,
+) -> bool {
+    let name = to_str!(name_ptr, name_len);
+    let json = unsafe { std::slice::from_raw_parts(json_ptr, json_len) };
+    let ty = match exec_context.scheme().get_field(name) {
+        Ok(field) => field.get_type(),
+        Err(err) => {
+            write_last_error!("{}", err);
+            return false;
+        }
+    };
+    let value = match ty.deserialize_value(&mut serde_json::Deserializer::from_reader(json)) {
+        Ok(value) => value,
+        Err(err) => {
+            write_last_error!("{}", err);
+            return false;
+        }
+    };
+    match exec_context.set_field_value_from_name(name, value) {
+        Ok(_) => true,
+        Err(err) => {
+            write_last_error!("{}", err);
+            false
+        }
+    }
 }
 
 #[unsafe(no_mangle)]
@@ -623,205 +632,6 @@ pub extern "C" fn wirefilter_add_bool_value_to_execution_context(
 ) -> bool {
     let name = to_str!(name_ptr, name_len);
     exec_context.set_field_value_from_name(name, value).is_ok()
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn wirefilter_add_map_value_to_execution_context<'a>(
-    exec_context: &mut ExecutionContext<'a>,
-    name_ptr: *const c_char,
-    name_len: usize,
-    value: Box<Map<'a>>,
-) -> bool {
-    let name = to_str!(name_ptr, name_len);
-    exec_context.set_field_value_from_name(name, *value).is_ok()
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn wirefilter_add_array_value_to_execution_context<'a>(
-    exec_context: &mut ExecutionContext<'a>,
-    name_ptr: *const c_char,
-    name_len: usize,
-    value: Box<Array<'a>>,
-) -> bool {
-    let name = to_str!(name_ptr, name_len);
-    exec_context.set_field_value_from_name(name, *value).is_ok()
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn wirefilter_create_map<'a>(ty: CType) -> Box<Map<'a>> {
-    Box::new(Map(wirefilter::Map::new(Type::from(ty))))
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn wirefilter_add_int_value_to_map(
-    map: &mut Map<'_>,
-    name_ptr: *const u8,
-    name_len: usize,
-    value: i64,
-) -> bool {
-    assert!(!name_ptr.is_null());
-    let name = unsafe { std::slice::from_raw_parts(name_ptr, name_len) };
-    map.insert(name, value).is_ok()
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn wirefilter_add_bytes_value_to_map(
-    map: &mut Map<'_>,
-    name_ptr: *const u8,
-    name_len: usize,
-    value_ptr: *const u8,
-    value_len: usize,
-) -> bool {
-    assert!(!name_ptr.is_null());
-    let name = unsafe { std::slice::from_raw_parts(name_ptr, name_len) };
-    assert!(!value_ptr.is_null());
-    let value = unsafe { std::slice::from_raw_parts(value_ptr, value_len) };
-    map.insert(name, value).is_ok()
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn wirefilter_add_ipv6_value_to_map(
-    map: &mut Map<'_>,
-    name_ptr: *const u8,
-    name_len: usize,
-    value: &[u8; 16],
-) -> bool {
-    assert!(!name_ptr.is_null());
-    let name = unsafe { std::slice::from_raw_parts(name_ptr, name_len) };
-    let value = IpAddr::from(*value);
-    map.insert(name, value).is_ok()
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn wirefilter_add_ipv4_value_to_map(
-    map: &mut Map<'_>,
-    name_ptr: *const u8,
-    name_len: usize,
-    value: &[u8; 4],
-) -> bool {
-    assert!(!name_ptr.is_null());
-    let name = unsafe { std::slice::from_raw_parts(name_ptr, name_len) };
-    let value = IpAddr::from(*value);
-    map.insert(name, value).is_ok()
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn wirefilter_add_bool_value_to_map(
-    map: &mut Map<'_>,
-    name_ptr: *const u8,
-    name_len: usize,
-    value: bool,
-) -> bool {
-    assert!(!name_ptr.is_null());
-    let name = unsafe { std::slice::from_raw_parts(name_ptr, name_len) };
-    map.insert(name, value).is_ok()
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn wirefilter_add_map_value_to_map<'a>(
-    map: &mut Map<'a>,
-    name_ptr: *const u8,
-    name_len: usize,
-    value: Box<Map<'a>>,
-) -> bool {
-    assert!(!name_ptr.is_null());
-    let name = unsafe { std::slice::from_raw_parts(name_ptr, name_len) };
-    map.insert(name, *value).is_ok()
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn wirefilter_add_array_value_to_map<'a>(
-    map: &mut Map<'a>,
-    name_ptr: *const u8,
-    name_len: usize,
-    value: Box<Array<'a>>,
-) -> bool {
-    assert!(!name_ptr.is_null());
-    let name = unsafe { std::slice::from_raw_parts(name_ptr, name_len) };
-    map.insert(name, *value).is_ok()
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn wirefilter_free_map(map: Box<Map<'_>>) {
-    drop(map)
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn wirefilter_create_array<'a>(ty: CType) -> Box<Array<'a>> {
-    Box::new(Array(wirefilter::Array::new(Type::from(ty))))
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn wirefilter_add_int_value_to_array(
-    array: &mut Array<'_>,
-    index: u32,
-    value: i64,
-) -> bool {
-    array.insert(index.try_into().unwrap(), value).is_ok()
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn wirefilter_add_bytes_value_to_array(
-    array: &mut Array<'_>,
-    index: u32,
-    value_ptr: *const u8,
-    value_len: usize,
-) -> bool {
-    assert!(!value_ptr.is_null());
-    let value = unsafe { std::slice::from_raw_parts(value_ptr, value_len) };
-    array.insert(index.try_into().unwrap(), value).is_ok()
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn wirefilter_add_ipv6_value_to_array(
-    array: &mut Array<'_>,
-    index: u32,
-    value: &[u8; 16],
-) -> bool {
-    let value = IpAddr::from(*value);
-    array.insert(index.try_into().unwrap(), value).is_ok()
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn wirefilter_add_ipv4_value_to_array(
-    array: &mut Array<'_>,
-    index: u32,
-    value: &[u8; 4],
-) -> bool {
-    let value = IpAddr::from(*value);
-    array.insert(index.try_into().unwrap(), value).is_ok()
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn wirefilter_add_bool_value_to_array(
-    array: &mut Array<'_>,
-    index: u32,
-    value: bool,
-) -> bool {
-    array.insert(index.try_into().unwrap(), value).is_ok()
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn wirefilter_add_map_value_to_array<'a>(
-    array: &mut Array<'a>,
-    index: u32,
-    value: Box<Map<'a>>,
-) -> bool {
-    array.insert(index.try_into().unwrap(), *value).is_ok()
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn wirefilter_add_array_value_to_array<'a>(
-    array: &mut Array<'a>,
-    index: u32,
-    value: Box<Array<'a>>,
-) -> bool {
-    array.insert(index.try_into().unwrap(), *value).is_ok()
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn wirefilter_free_array(array: Box<Array<'_>>) {
-    drop(array)
 }
 
 #[derive(Debug)]
@@ -1021,6 +831,7 @@ pub extern "C" fn wirefilter_get_version() -> StaticRustAllocatedString {
 mod ffi_test {
     use super::*;
     use regex_automata::meta::Regex;
+    use serde_json::json;
     use std::ffi::CStr;
 
     impl RustAllocatedString {
@@ -1137,49 +948,27 @@ mod ffi_test {
             1337,
         ));
 
-        let mut map1 = wirefilter_create_map(Type::Int.into());
-
-        let key = b"key";
-        wirefilter_add_int_value_to_map(&mut map1, key.as_ptr(), key.len(), 42);
-
-        wirefilter_add_int_value_to_map(&mut map1, invalid_key.as_ptr(), invalid_key.len(), 42);
+        let json = json!([["key", 42], [invalid_key, 42]]).to_string();
 
         let field = "map1";
-        wirefilter_add_map_value_to_execution_context(
+        assert!(wirefilter_add_json_value_to_execution_context(
             &mut exec_context,
             field.as_ptr().cast(),
             field.len(),
-            map1,
-        );
+            json.as_bytes().as_ptr(),
+            json.len(),
+        ));
 
-        let mut map2 = wirefilter_create_map(Type::Bytes.into());
-
-        let key = b"key";
-        let value = "value";
-        wirefilter_add_bytes_value_to_map(
-            &mut map2,
-            key.as_ptr(),
-            key.len(),
-            value.as_ptr(),
-            value.len(),
-        );
-
-        let value = "value";
-        wirefilter_add_bytes_value_to_map(
-            &mut map2,
-            invalid_key.as_ptr(),
-            invalid_key.len(),
-            value.as_ptr(),
-            value.len(),
-        );
+        let json = json!([["key", "value"], [invalid_key, "value"]]).to_string();
 
         let field = "map2";
-        wirefilter_add_map_value_to_execution_context(
+        assert!(wirefilter_add_json_value_to_execution_context(
             &mut exec_context,
             field.as_ptr().cast(),
             field.len(),
-            map2,
-        );
+            json.as_ptr().cast(),
+            json.len(),
+        ));
 
         exec_context
     }

--- a/ffi/tests/ctests/src/tests.c
+++ b/ffi/tests/ctests/src/tests.c
@@ -461,24 +461,6 @@ void wirefilter_ffi_ctest_add_values_to_execution_context_errors() {
         80
     ) == false, "managed to set value for non-existent int field");
 
-    struct wirefilter_map *more_http_headers = wirefilter_create_map(
-        WIREFILTER_TYPE_BYTES
-    );
-    rust_assert(wirefilter_add_map_value_to_execution_context(
-        exec_ctx,
-        STRING("doesnotexist"),
-        more_http_headers
-    ) == false, "managed to set value for non-existent map field");
-
-    struct wirefilter_array *http_cookies = wirefilter_create_array(
-        WIREFILTER_TYPE_BYTES
-    );
-    rust_assert(wirefilter_add_array_value_to_execution_context(
-        exec_ctx,
-        STRING("doesnotexist"),
-        http_cookies
-    ) == false, "managed to set value for non-existent array field");
-
     wirefilter_free_execution_context(exec_ctx);
 
     wirefilter_free_scheme(scheme);
@@ -701,21 +683,15 @@ void wirefilter_ffi_ctest_match_map() {
         80
     );
 
-    struct wirefilter_map *http_headers = wirefilter_create_map(
-        WIREFILTER_TYPE_BYTES
+    const char *json = "{\"host\":\"www.cloudflare.com\"}";
+    rust_assert(
+        wirefilter_add_json_value_to_execution_context(
+            exec_ctx,
+            STRING("http.headers"),
+            BYTES(json)
+        ) == true,
+        "could not set value for map field http.headers"
     );
-
-    rust_assert(wirefilter_add_bytes_value_to_map(
-        http_headers,
-        BYTES("host"),
-        BYTES("www.cloudflare.com")
-    ), "could not add bytes value to map");
-
-    rust_assert(wirefilter_add_map_value_to_execution_context(
-        exec_ctx,
-        STRING("http.headers"),
-        http_headers
-    ) == true, "could not set value for map field http.headers");
 
     struct wirefilter_matching_result matching_result = wirefilter_match(filter, exec_ctx);
     rust_assert(matching_result.status == WIREFILTER_STATUS_SUCCESS, "could not match filter");
@@ -773,33 +749,15 @@ void wirefilter_ffi_ctest_match_array() {
         80
     );
 
-    struct wirefilter_array *http_cookies = wirefilter_create_array(
-        WIREFILTER_TYPE_BYTES
+    const char *json = "[\"one\", \"two\", \"www.cloudflare.com\"]";
+    rust_assert(
+        wirefilter_add_json_value_to_execution_context(
+            exec_ctx,
+            STRING("http.cookies"),
+            BYTES(json)
+        ) == true,
+        "could not set value for map field http.cookies"
     );
-
-    rust_assert(wirefilter_add_bytes_value_to_array(
-        http_cookies,
-        0,
-        BYTES("one")
-    ), "could not add bytes value to array");
-
-    rust_assert(wirefilter_add_bytes_value_to_array(
-        http_cookies,
-        1,
-        BYTES("two")
-    ), "could not add bytes value to array");
-
-    rust_assert(wirefilter_add_bytes_value_to_array(
-        http_cookies,
-        2,
-        BYTES("www.cloudflare.com")
-    ), "could not add bytes value to array");
-
-    rust_assert(wirefilter_add_array_value_to_execution_context(
-        exec_ctx,
-        STRING("http.cookies"),
-        http_cookies
-    ) == true, "could not set value for map field http.cookies");
 
     struct wirefilter_matching_result matching_result = wirefilter_match(filter, exec_ctx);
     rust_assert(matching_result.status == WIREFILTER_STATUS_SUCCESS, "could not match filter");


### PR DESCRIPTION
This is done in order to try different optimizations.

The idiomatic way to build such collections is either to use their typed equivalents or through `try_from_iter` and related constructors.