### PR TITLE
Rework `Scheme` serialization

### DIFF
--- a/ffi/tests/ctests/src/tests.c
+++ b/ffi/tests/ctests/src/tests.c
@@ -305,7 +305,7 @@ void wirefilter_ffi_ctest_scheme_serialize() {
     rust_assert(json.ptr != NULL && json.len > 0, "could not serialize scheme to JSON");
 
     rust_assert(
-        strncmp(json.ptr, "{\"http.host\":\"Bytes\",\"ip.src\":\"Ip\",\"ip.dst\":\"Ip\",\"ssl\":\"Bool\",\"tcp.port\":\"Int\",\"http.headers\":{\"Map\":\"Bytes\"},\"http.cookies\":{\"Array\":\"Bytes\"}}", json.len) == 0,
+        strncmp(json.ptr, "{\"http.host\":{\"type\":\"Bytes\"},\"ip.src\":{\"type\":\"Ip\"},\"ip.dst\":{\"type\":\"Ip\"},\"ssl\":{\"type\":\"Bool\"},\"tcp.port\":{\"type\":\"Int\"},\"http.headers\":{\"type\":{\"Map\":\"Bytes\"}},\"http.cookies\":{\"type\":{\"Array\":\"Bytes\"}}}", json.len) == 0,
         "invalid JSON serialization"
     );
 


### PR DESCRIPTION
This change is a necessary rework of scheme serialization to allow for additional field properties that will be introduced in a future commit.

Before this change, a serialized scheme was a map of field name to field type. After this change, a serialized scheme is a map of field name to field definition object, which only contain its type for now but can be extended with additional properties.