### PR TITLE
update README example to match current implementation

### DIFF
--- a/engine/README.md
+++ b/engine/README.md
@@ -12,7 +12,7 @@ an executable IR and, finally, executing filters against provided values.
 ## Example
 
 ```rust
-use wirefilter::{ExecutionContext, Scheme, Type};
+use wirefilter::{ExecutionContext, Scheme};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a map of possible filter fields.
@@ -20,14 +20,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         http.method: Bytes,
         http.ua: Bytes,
         port: Int,
-    };
+    }
+    .build();
 
     // Parse a Wireshark-like expression into an AST.
-    let ast = scheme.parse(r#"
-        http.method != "POST" &&
-        not http.ua matches "(googlebot|facebook)" &&
-        port in {80 443}
-    "#)?;
+    let ast = scheme.parse(
+        r#"
+            http.method != "POST" &&
+            not http.ua matches "(googlebot|facebook)" &&
+            port in {80 443}
+        "#,
+    )?;
 
     println!("Parsed filter representation: {:?}", ast);
 

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -6,7 +6,7 @@
 //! # Example
 //!
 //! ```
-//! use wirefilter::{ExecutionContext, Scheme, Type};
+//! use wirefilter::{ExecutionContext, Scheme};
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     // Create a map of possible filter fields.
@@ -14,7 +14,8 @@
 //!         http.method: Bytes,
 //!         http.ua: Bytes,
 //!         port: Int,
-//!     }.build();
+//!     }
+//!     .build();
 //!
 //!     // Parse a Wireshark-like expression into an AST.
 //!     let ast = scheme.parse(


### PR DESCRIPTION
- the .build() call is required to align with recent rework of serialization
- 'Type' was unused

I, mtovino@cloudflare.com, am both a rust n00b and a wirefilter n00b.  I tried building the example so that I could tinker and learn, and needed to make these changes for the example to build and lint.  