### PR TITLE
Disable regex onepass DFA

### DIFF
--- a/engine/src/rhs_types/regex/imp_real.rs
+++ b/engine/src/rhs_types/regex/imp_real.rs
@@ -30,7 +30,7 @@ impl Regex {
             .utf8_empty(false)
             .dfa(false)
             .nfa_size_limit(Some(settings.regex_compiled_size_limit))
-            .onepass_size_limit(Some(settings.regex_compiled_size_limit))
+            .onepass(false)
             .dfa_size_limit(Some(settings.regex_compiled_size_limit))
             .hybrid_cache_capacity(settings.regex_dfa_size_limit)
     }


### PR DESCRIPTION
Benchmarks have shown that disabling onepass doesn't impact matching performance but speeds-up regex building and should also reduce memory usage.