### PR TITLE
Fix rustfmt.toml & format code

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 env:
   CARGO_TERM_COLOR: always
@@ -12,29 +12,29 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        toolchain: stable
-        components: clippy,rustfmt
-    - uses: tombi-toml/setup-tombi@v1
-    - name: Print versions
-      run: |
-        cargo --version
-        rustc --version
-        clippy-driver --version
-        rustfmt --version
-        tombi --version
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
-    - name: Run clippy
-      run: cargo clippy --verbose --all-targets -- -D clippy::all
-    - name: Check code formatting
-      run: cargo fmt --verbose --all -- --check
-    - name: Check toml formatting
-      run: tombi format --check
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy,rustfmt
+      - uses: tombi-toml/setup-tombi@v1
+      - name: Print versions
+        run: |
+          cargo --version
+          rustc --version
+          clippy-driver --version
+          rustfmt --version
+          tombi --version
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose
+      - name: Run clippy
+        run: cargo clippy --verbose --all-targets -- -D clippy::all
+      - name: Check code formatting
+        run: cargo fmt --verbose --all -- --check
+      - name: Check toml formatting
+        run: tombi format --check
 
   doc:
     name: Documentation
@@ -42,19 +42,19 @@ jobs:
     env:
       RUSTDOCFLAGS: -D warnings
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        toolchain: stable
-    - name: Print versions
-      run: |
-        cargo --version
-        rustc --version
-        rustdoc --version
-    - name: Doc
-      run: cargo doc --verbose
-    - name: Doc with all features
-      run: cargo doc --verbose --all-features
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+      - name: Print versions
+        run: |
+          cargo --version
+          rustc --version
+          rustdoc --version
+      - name: Doc
+        run: cargo doc --verbose
+      - name: Doc with all features
+        run: cargo doc --verbose --all-features
 
   miri-test:
     name: Test with miri
@@ -62,13 +62,13 @@ jobs:
     env:
       MIRIFLAGS: -Zmiri-disable-isolation
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        toolchain: nightly
-        components: miri
-    - run: cargo miri test --verbose --no-default-features
-    - run: cargo miri test --verbose --all-features
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+          components: miri
+      - run: cargo miri test --verbose --no-default-features
+      - run: cargo miri test --verbose --all-features
 
   sanitizer-test:
     name: Test with -Zsanitizer=${{ matrix.sanitizer }}
@@ -78,19 +78,19 @@ jobs:
       matrix:
         sanitizer: [address, thread, leak]
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        toolchain: nightly
-        components: rust-src
-    - name: Test with sanitizer
-      env:
-        RUSTFLAGS: -Zsanitizer=${{ matrix.sanitizer }}
-        RUSTDOCFLAGS: -Zsanitizer=${{ matrix.sanitizer }}
-        # only needed by asan
-        ASAN_OPTIONS: detect_stack_use_after_return=1,detect_leaks=0
-        # Asan's leak detection occasionally complains
-        # about some small leaks if backtraces are captured,
-        # so ensure they're not
-        RUST_BACKTRACE: 0
-      run: cargo test -Zbuild-std --verbose --target=x86_64-unknown-linux-gnu --lib --bins --tests
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+          components: rust-src
+      - name: Test with sanitizer
+        env:
+          RUSTFLAGS: -Zsanitizer=${{ matrix.sanitizer }}
+          RUSTDOCFLAGS: -Zsanitizer=${{ matrix.sanitizer }}
+          # only needed by asan
+          ASAN_OPTIONS: detect_stack_use_after_return=1,detect_leaks=0
+          # Asan's leak detection occasionally complains
+          # about some small leaks if backtraces are captured,
+          # so ensure they're not
+          RUST_BACKTRACE: 0
+        run: cargo test -Zbuild-std --verbose --target=x86_64-unknown-linux-gnu --lib --bins --tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,23 +16,34 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-          components: clippy,rustfmt
-      - uses: tombi-toml/setup-tombi@v1
+          components: clippy
       - name: Print versions
         run: |
           cargo --version
           rustc --version
           clippy-driver --version
-          rustfmt --version
-          tombi --version
       - name: Build
         run: cargo build --verbose
       - name: Run tests
         run: cargo test --verbose
       - name: Run clippy
         run: cargo clippy --verbose --all-targets -- -D clippy::all
+
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+          components: rustfmt
+      - uses: tombi-toml/setup-tombi@v1
+      - name: Print versions
+        run: |
+          cargo fmt --version
+          tombi --version
       - name: Check code formatting
-        run: cargo fmt --verbose --all -- --check
+        uses: actions-rust-lang/rustfmt@v1
       - name: Check toml formatting
         run: tombi format --check
 

--- a/engine/benches/bench.rs
+++ b/engine/benches/bench.rs
@@ -6,7 +6,9 @@ use std::alloc::System;
 static A: System = System;
 
 use criterion::{Bencher, Criterion, criterion_group, criterion_main};
-use std::{clone::Clone, fmt::Debug, net::IpAddr};
+use std::clone::Clone;
+use std::fmt::Debug;
+use std::net::IpAddr;
 use wirefilter::{
     Bytes, ExecutionContext, FilterAst, FunctionArgs, GetType, LhsValue, SchemeBuilder,
     SimpleFunctionArgKind, SimpleFunctionDefinition, SimpleFunctionImpl, SimpleFunctionParam, Type,

--- a/engine/src/ast/field_expr.rs
+++ b/engine/src/ast/field_expr.rs
@@ -1,22 +1,18 @@
-use super::{
-    Expr,
-    function_expr::FunctionCallExpr,
-    parse::FilterParser,
-    visitor::{Visitor, VisitorMut},
-};
-use crate::{
-    ExecutionContext, Scheme,
-    ast::index_expr::{Compare, IndexExpr},
-    compiler::Compiler,
-    filter::CompiledExpr,
-    lex::{Lex, LexErrorKind, LexResult, LexWith, expect, skip_space, span},
-    range_set::RangeSet,
-    rhs_types::{BytesExpr, ExplicitIpRange, ListName, Regex, Wildcard},
-    scheme::{Field, Identifier, List},
-    searcher::{EmptySearcher, MemmemSearcher},
-    strict_partial_ord::StrictPartialOrd,
-    types::{GetType, LhsValue, RhsValue, RhsValues, Type},
-};
+use super::Expr;
+use super::function_expr::FunctionCallExpr;
+use super::parse::FilterParser;
+use super::visitor::{Visitor, VisitorMut};
+use crate::ast::index_expr::{Compare, IndexExpr};
+use crate::compiler::Compiler;
+use crate::filter::CompiledExpr;
+use crate::lex::{Lex, LexErrorKind, LexResult, LexWith, expect, skip_space, span};
+use crate::range_set::RangeSet;
+use crate::rhs_types::{BytesExpr, ExplicitIpRange, ListName, Regex, Wildcard};
+use crate::scheme::{Field, Identifier, List};
+use crate::searcher::{EmptySearcher, MemmemSearcher};
+use crate::strict_partial_ord::StrictPartialOrd;
+use crate::types::{GetType, LhsValue, RhsValue, RhsValues, Type};
+use crate::{ExecutionContext, Scheme};
 use serde::{Serialize, Serializer};
 use sliceslice::MemchrSearcher;
 use std::cmp::Ordering;
@@ -798,29 +794,29 @@ impl Expr for ComparisonExpr {
 #[allow(clippy::bool_assert_comparison)]
 mod tests {
     use super::*;
+    use crate::ast::function_expr::{FunctionCallArgExpr, FunctionCallExpr};
+    use crate::ast::logical_expr::LogicalExpr;
+    use crate::execution_context::ExecutionContext;
+    use crate::functions::{
+        FunctionArgKind, FunctionArgs, FunctionDefinition, FunctionDefinitionContext,
+        FunctionParam, FunctionParamError, SimpleFunctionDefinition, SimpleFunctionImpl,
+        SimpleFunctionOptParam, SimpleFunctionParam,
+    };
+    use crate::lhs_types::{Array, Map};
+    use crate::list_matcher::{ListDefinition, ListMatcher};
+    use crate::rhs_types::{IpRange, RegexFormat};
+    use crate::scheme::{FieldIndex, IndexAccessError, Scheme};
+    use crate::types::ExpectedType;
     use crate::{
         BytesFormat, FieldRef, LhsValue, ParserSettings, SchemeBuilder, SimpleFunctionArgKind,
         TypedMap,
-        ast::{
-            function_expr::{FunctionCallArgExpr, FunctionCallExpr},
-            logical_expr::LogicalExpr,
-        },
-        execution_context::ExecutionContext,
-        functions::{
-            FunctionArgKind, FunctionArgs, FunctionDefinition, FunctionDefinitionContext,
-            FunctionParam, FunctionParamError, SimpleFunctionDefinition, SimpleFunctionImpl,
-            SimpleFunctionOptParam, SimpleFunctionParam,
-        },
-        lhs_types::{Array, Map},
-        list_matcher::{ListDefinition, ListMatcher},
-        rhs_types::{IpRange, RegexFormat},
-        scheme::{FieldIndex, IndexAccessError, Scheme},
-        types::ExpectedType,
     };
     use cidr::IpCidr;
     use serde::Deserialize;
+    use std::convert::TryFrom;
+    use std::iter::once;
+    use std::net::IpAddr;
     use std::sync::LazyLock;
-    use std::{convert::TryFrom, iter::once, net::IpAddr};
 
     fn any_function<'a>(args: FunctionArgs<'_, 'a>) -> Option<LhsValue<'a>> {
         match args.next()? {

--- a/engine/src/ast/function_expr.rs
+++ b/engine/src/ast/function_expr.rs
@@ -1,26 +1,20 @@
-use super::{
-    ValueExpr,
-    parse::FilterParser,
-    visitor::{Visitor, VisitorMut},
+use super::ValueExpr;
+use super::parse::FilterParser;
+use super::visitor::{Visitor, VisitorMut};
+use crate::FunctionRef;
+use crate::ast::field_expr::{ComparisonExpr, ComparisonOp, ComparisonOpExpr};
+use crate::ast::index_expr::IndexExpr;
+use crate::ast::logical_expr::{LogicalExpr, UnaryOp};
+use crate::compiler::Compiler;
+use crate::filter::{CompiledExpr, CompiledValueExpr, CompiledValueResult};
+use crate::functions::{
+    ExactSizeChain, FunctionArgs, FunctionDefinition, FunctionDefinitionContext, FunctionParam,
+    FunctionParamError,
 };
-use crate::{
-    FunctionRef,
-    ast::{
-        field_expr::{ComparisonExpr, ComparisonOp, ComparisonOpExpr},
-        index_expr::IndexExpr,
-        logical_expr::{LogicalExpr, UnaryOp},
-    },
-    compiler::Compiler,
-    filter::{CompiledExpr, CompiledValueExpr, CompiledValueResult},
-    functions::{
-        ExactSizeChain, FunctionArgs, FunctionDefinition, FunctionDefinitionContext, FunctionParam,
-        FunctionParamError,
-    },
-    lex::{Lex, LexError, LexErrorKind, LexResult, LexWith, expect, skip_space, span},
-    lhs_types::Array,
-    scheme::Function,
-    types::{GetType, LhsValue, RhsValue, Type},
-};
+use crate::lex::{Lex, LexError, LexErrorKind, LexResult, LexWith, expect, skip_space, span};
+use crate::lhs_types::Array;
+use crate::scheme::Function;
+use crate::types::{GetType, LhsValue, RhsValue, Type};
 use serde::Serialize;
 use std::hash::{Hash, Hasher};
 use std::iter::once;
@@ -526,21 +520,17 @@ impl<'i> LexWith<'i, &FilterParser<'_>> for FunctionCallExpr {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        SimpleFunctionArgKind,
-        ast::{
-            field_expr::{ComparisonExpr, ComparisonOpExpr, IdentifierExpr, OrderingOp},
-            logical_expr::{LogicalExpr, LogicalOp, ParenthesizedExpr},
-            parse::FilterParser,
-        },
-        functions::{
-            FunctionArgKind, FunctionArgKindMismatchError, FunctionArgs, SimpleFunctionDefinition,
-            SimpleFunctionImpl, SimpleFunctionOptParam, SimpleFunctionParam,
-        },
-        rhs_types::{BytesExpr, BytesFormat},
-        scheme::{FieldIndex, IndexAccessError, Scheme},
-        types::{RhsValues, Type, TypeMismatchError},
+    use crate::SimpleFunctionArgKind;
+    use crate::ast::field_expr::{ComparisonExpr, ComparisonOpExpr, IdentifierExpr, OrderingOp};
+    use crate::ast::logical_expr::{LogicalExpr, LogicalOp, ParenthesizedExpr};
+    use crate::ast::parse::FilterParser;
+    use crate::functions::{
+        FunctionArgKind, FunctionArgKindMismatchError, FunctionArgs, SimpleFunctionDefinition,
+        SimpleFunctionImpl, SimpleFunctionOptParam, SimpleFunctionParam,
     };
+    use crate::rhs_types::{BytesExpr, BytesFormat};
+    use crate::scheme::{FieldIndex, IndexAccessError, Scheme};
+    use crate::types::{RhsValues, Type, TypeMismatchError};
     use std::convert::TryFrom;
     use std::sync::LazyLock;
 

--- a/engine/src/ast/index_expr.rs
+++ b/engine/src/ast/index_expr.rs
@@ -1,19 +1,16 @@
-use super::{
-    ValueExpr,
-    field_expr::IdentifierExpr,
-    parse::FilterParser,
-    visitor::{Visitor, VisitorMut},
-};
-use crate::{
-    compiler::Compiler,
-    execution_context::ExecutionContext,
-    filter::{CompiledExpr, CompiledOneExpr, CompiledValueExpr, CompiledVecExpr},
-    lex::{Lex, LexErrorKind, LexResult, LexWith, expect, skip_space, span},
-    lhs_types::{Array, Map, TypedArray},
-    scheme::{FieldIndex, IndexAccessError},
-    types::{GetType, IntoIter, LhsValue, Type},
-};
-use serde::{Serialize, Serializer, ser::SerializeSeq};
+use super::ValueExpr;
+use super::field_expr::IdentifierExpr;
+use super::parse::FilterParser;
+use super::visitor::{Visitor, VisitorMut};
+use crate::compiler::Compiler;
+use crate::execution_context::ExecutionContext;
+use crate::filter::{CompiledExpr, CompiledOneExpr, CompiledValueExpr, CompiledVecExpr};
+use crate::lex::{Lex, LexErrorKind, LexResult, LexWith, expect, skip_space, span};
+use crate::lhs_types::{Array, Map, TypedArray};
+use crate::scheme::{FieldIndex, IndexAccessError};
+use crate::types::{GetType, IntoIter, LhsValue, Type};
+use serde::ser::SerializeSeq;
+use serde::{Serialize, Serializer};
 
 const BOOL_ARRAY: TypedArray<'_, bool> = TypedArray::new();
 
@@ -528,10 +525,11 @@ impl<'a> Iterator for MapEachIterator<'a, '_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ast::field_expr::IdentifierExpr;
     use crate::{
         Array, FieldIndex, FilterParser, FunctionArgs, FunctionCallArgExpr, FunctionCallExpr,
         Scheme, SchemeBuilder, SimpleFunctionArgKind, SimpleFunctionDefinition, SimpleFunctionImpl,
-        SimpleFunctionParam, ast::field_expr::IdentifierExpr,
+        SimpleFunctionParam,
     };
     use std::sync::LazyLock;
 

--- a/engine/src/ast/logical_expr.rs
+++ b/engine/src/ast/logical_expr.rs
@@ -1,15 +1,11 @@
-use super::{
-    Expr,
-    field_expr::ComparisonExpr,
-    parse::FilterParser,
-    visitor::{Visitor, VisitorMut},
-};
-use crate::{
-    compiler::Compiler,
-    filter::{CompiledExpr, CompiledOneExpr, CompiledVecExpr},
-    lex::{Lex, LexErrorKind, LexResult, LexWith, expect, skip_space},
-    types::{GetType, Type, TypeMismatchError},
-};
+use super::Expr;
+use super::field_expr::ComparisonExpr;
+use super::parse::FilterParser;
+use super::visitor::{Visitor, VisitorMut};
+use crate::compiler::Compiler;
+use crate::filter::{CompiledExpr, CompiledOneExpr, CompiledVecExpr};
+use crate::lex::{Lex, LexErrorKind, LexResult, LexWith, expect, skip_space};
+use crate::types::{GetType, Type, TypeMismatchError};
 use serde::Serialize;
 
 lex_enum!(
@@ -326,15 +322,13 @@ impl Expr for LogicalExpr {
 #[allow(clippy::cognitive_complexity)]
 fn test() {
     use super::field_expr::ComparisonExpr;
-    use crate::{
-        ast::field_expr::{ComparisonOpExpr, IdentifierExpr},
-        ast::index_expr::IndexExpr,
-        execution_context::ExecutionContext,
-        lex::complete,
-        lhs_types::Array,
-        scheme::FieldIndex,
-        types::Type,
-    };
+    use crate::ast::field_expr::{ComparisonOpExpr, IdentifierExpr};
+    use crate::ast::index_expr::IndexExpr;
+    use crate::execution_context::ExecutionContext;
+    use crate::lex::complete;
+    use crate::lhs_types::Array;
+    use crate::scheme::FieldIndex;
+    use crate::types::Type;
 
     let scheme = &Scheme! {
         t: Bool,

--- a/engine/src/ast/mod.rs
+++ b/engine/src/ast/mod.rs
@@ -8,16 +8,14 @@ pub mod visitor;
 use self::index_expr::IndexExpr;
 use self::logical_expr::LogicalExpr;
 use self::parse::FilterParser;
-use crate::{
-    compiler::{Compiler, DefaultCompiler},
-    filter::{CompiledExpr, CompiledValueExpr, Filter, FilterValue},
-    lex::{LexErrorKind, LexResult, LexWith},
-    scheme::{Scheme, UnknownFieldError},
-    types::{GetType, Type, TypeMismatchError},
-};
+use self::visitor::{UsesListVisitor, UsesVisitor, Visitor, VisitorMut};
+use crate::compiler::{Compiler, DefaultCompiler};
+use crate::filter::{CompiledExpr, CompiledValueExpr, Filter, FilterValue};
+use crate::lex::{LexErrorKind, LexResult, LexWith};
+use crate::scheme::{Scheme, UnknownFieldError};
+use crate::types::{GetType, Type, TypeMismatchError};
 use serde::Serialize;
 use std::fmt::{self, Debug};
-use visitor::{UsesListVisitor, UsesVisitor, Visitor, VisitorMut};
 
 /// Trait used to represent node that evaluates to a [`bool`] (or a [`Vec<bool>`]).
 pub trait Expr:

--- a/engine/src/ast/parse.rs
+++ b/engine/src/ast/parse.rs
@@ -1,8 +1,6 @@
 use super::{FilterAst, FilterValueAst};
-use crate::{
-    lex::{LexErrorKind, LexResult, LexWith, complete},
-    scheme::Scheme,
-};
+use crate::lex::{LexErrorKind, LexResult, LexWith, complete};
+use crate::scheme::Scheme;
 use std::cmp::{max, min};
 use std::error::Error;
 use std::fmt::{self, Debug, Display, Formatter};

--- a/engine/src/ast/visitor.rs
+++ b/engine/src/ast/visitor.rs
@@ -1,10 +1,8 @@
-use super::{
-    Expr, ValueExpr,
-    field_expr::{ComparisonExpr, ComparisonOpExpr},
-    function_expr::{FunctionCallArgExpr, FunctionCallExpr},
-    index_expr::IndexExpr,
-    logical_expr::LogicalExpr,
-};
+use super::field_expr::{ComparisonExpr, ComparisonOpExpr};
+use super::function_expr::{FunctionCallArgExpr, FunctionCallExpr};
+use super::index_expr::IndexExpr;
+use super::logical_expr::LogicalExpr;
+use super::{Expr, ValueExpr};
 use crate::{Field, FieldRef, Function};
 
 /// Trait used to immutably visit all nodes in the AST.

--- a/engine/src/execution_context.rs
+++ b/engine/src/execution_context.rs
@@ -1,8 +1,6 @@
-use crate::{
-    FieldRef, ListMatcher, ListRef, UnknownFieldError,
-    scheme::{Field, List, Scheme, SchemeMismatchError},
-    types::{GetType, LhsValue, LhsValueSeed, Type, TypeMismatchError},
-};
+use crate::scheme::{Field, List, Scheme, SchemeMismatchError};
+use crate::types::{GetType, LhsValue, LhsValueSeed, Type, TypeMismatchError};
+use crate::{FieldRef, ListMatcher, ListRef, UnknownFieldError};
 use serde::Serialize;
 use serde::de::{self, DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor};
 use serde::ser::{SerializeMap, SerializeSeq, Serializer};

--- a/engine/src/filter.rs
+++ b/engine/src/filter.rs
@@ -5,12 +5,10 @@
 //! their `execute` methods and aggregating results into a single boolean value
 //! as recursion unwinds.
 
-use crate::{
-    execution_context::ExecutionContext,
-    lhs_types::TypedArray,
-    scheme::{Scheme, SchemeMismatchError},
-    types::{LhsValue, Type},
-};
+use crate::execution_context::ExecutionContext;
+use crate::lhs_types::TypedArray;
+use crate::scheme::{Scheme, SchemeMismatchError};
+use crate::types::{LhsValue, Type};
 use std::fmt;
 
 type BoxedClosureToOneBool<U> =

--- a/engine/src/functions/mod.rs
+++ b/engine/src/functions/mod.rs
@@ -407,7 +407,7 @@ pub trait FunctionDefinition: Debug + Send + Sync {
     ) -> Box<dyn for<'i, 'a> Fn(FunctionArgs<'i, 'a>) -> Option<LhsValue<'a>> + Sync + Send + 'static>;
 }
 
-/* Simple function APIs */
+// Simple function APIs
 
 type FunctionPtr = for<'i, 'a> fn(FunctionArgs<'i, 'a>) -> Option<LhsValue<'a>>;
 

--- a/engine/src/functions/mod.rs
+++ b/engine/src/functions/mod.rs
@@ -2,14 +2,14 @@ pub(crate) mod all;
 pub(crate) mod any;
 pub(crate) mod concat;
 
-use crate::{
-    ParserSettings,
-    filter::CompiledValueResult,
-    types::{ExpectedType, ExpectedTypeList, GetType, LhsValue, RhsValue, Type, TypeMismatchError},
+pub use self::all::AllFunction;
+pub use self::any::AnyFunction;
+pub use self::concat::ConcatFunction;
+use crate::ParserSettings;
+use crate::filter::CompiledValueResult;
+use crate::types::{
+    ExpectedType, ExpectedTypeList, GetType, LhsValue, RhsValue, Type, TypeMismatchError,
 };
-pub use all::AllFunction;
-pub use any::AnyFunction;
-pub use concat::ConcatFunction;
 use std::any::Any;
 use std::convert::TryFrom;
 use std::fmt::{self, Debug};

--- a/engine/src/lex.rs
+++ b/engine/src/lex.rs
@@ -1,9 +1,7 @@
-use crate::{
-    functions::{FunctionArgInvalidConstantError, FunctionArgKindMismatchError},
-    rhs_types::{RegexError, WildcardError},
-    scheme::{IndexAccessError, UnknownFieldError, UnknownFunctionError},
-    types::{Type, TypeMismatchError},
-};
+use crate::functions::{FunctionArgInvalidConstantError, FunctionArgKindMismatchError};
+use crate::rhs_types::{RegexError, WildcardError};
+use crate::scheme::{IndexAccessError, UnknownFieldError, UnknownFunctionError};
+use crate::types::{Type, TypeMismatchError};
 use cidr::errors::NetworkParseError;
 use std::num::ParseIntError;
 use thiserror::Error;

--- a/engine/src/lhs_types/array.rs
+++ b/engine/src/lhs_types/array.rs
@@ -1,19 +1,15 @@
-use crate::{
-    lhs_types::AsRefIterator,
-    types::{CompoundType, GetType, IntoValue, LhsValue, LhsValueSeed, Type, TypeMismatchError},
+use super::TypedMap;
+use super::map::InnerMap;
+use crate::lhs_types::AsRefIterator;
+use crate::types::{
+    CompoundType, GetType, IntoValue, LhsValue, LhsValueSeed, Type, TypeMismatchError,
 };
-use serde::{
-    Serialize, Serializer,
-    de::{self, DeserializeSeed, Deserializer, SeqAccess, Visitor},
-    ser::SerializeSeq,
-};
-use std::{
-    fmt,
-    hash::{Hash, Hasher},
-    hint::unreachable_unchecked,
-};
-
-use super::{TypedMap, map::InnerMap};
+use serde::de::{self, DeserializeSeed, Deserializer, SeqAccess, Visitor};
+use serde::ser::SerializeSeq;
+use serde::{Serialize, Serializer};
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::hint::unreachable_unchecked;
 
 // Ideally, we would want to use Cow<'a, LhsValue<'a>> here
 // but it doesnt work for unknown reasons

--- a/engine/src/lhs_types/array.rs
+++ b/engine/src/lhs_types/array.rs
@@ -322,8 +322,8 @@ impl ExactSizeIterator for ArrayIntoIter<'_> {
 }
 
 impl<'a> IntoIterator for Array<'a> {
-    type Item = LhsValue<'a>;
     type IntoIter = ArrayIntoIter<'a>;
+    type Item = LhsValue<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         match self.data {
@@ -357,8 +357,8 @@ impl ExactSizeIterator for ArrayIter<'_, '_> {
 }
 
 impl<'a, 'b> IntoIterator for &'b Array<'a> {
-    type Item = &'b LhsValue<'a>;
     type IntoIter = ArrayIter<'a, 'b>;
+    type Item = &'b LhsValue<'a>;
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {

--- a/engine/src/lhs_types/map.rs
+++ b/engine/src/lhs_types/map.rs
@@ -316,8 +316,8 @@ impl<'a> Iterator for MapIntoIter<'a> {
 }
 
 impl<'a> IntoIterator for Map<'a> {
-    type Item = (Cow<'a, [u8]>, LhsValue<'a>);
     type IntoIter = MapIntoIter<'a>;
+    type Item = (Cow<'a, [u8]>, LhsValue<'a>);
 
     fn into_iter(self) -> Self::IntoIter {
         match self.data {
@@ -328,8 +328,8 @@ impl<'a> IntoIterator for Map<'a> {
 }
 
 impl<'a, 'b> IntoIterator for &'b Map<'a> {
-    type Item = (&'b [u8], &'b LhsValue<'a>);
     type IntoIter = MapIter<'a, 'b>;
+    type Item = (&'b [u8], &'b LhsValue<'a>);
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {

--- a/engine/src/lhs_types/map.rs
+++ b/engine/src/lhs_types/map.rs
@@ -1,21 +1,15 @@
-use crate::{
-    TypeMismatchError,
-    lhs_types::{AsRefIterator, Bytes},
-    types::{CompoundType, GetType, IntoValue, LhsValue, LhsValueSeed, Type},
-};
-use serde::{
-    Serialize, Serializer,
-    de::{self, DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor},
-    ser::{SerializeMap, SerializeSeq},
-};
-use std::{
-    borrow::Cow,
-    collections::BTreeMap,
-    fmt,
-    hash::{Hash, Hasher},
-};
-
-use super::{TypedArray, array::InnerArray};
+use super::TypedArray;
+use super::array::InnerArray;
+use crate::TypeMismatchError;
+use crate::lhs_types::{AsRefIterator, Bytes};
+use crate::types::{CompoundType, GetType, IntoValue, LhsValue, LhsValueSeed, Type};
+use serde::de::{self, DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor};
+use serde::ser::{SerializeMap, SerializeSeq};
+use serde::{Serialize, Serializer};
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+use std::fmt;
+use std::hash::{Hash, Hasher};
 
 #[derive(Debug, Clone)]
 pub(crate) enum InnerMap<'a> {

--- a/engine/src/lhs_types/mod.rs
+++ b/engine/src/lhs_types/mod.rs
@@ -2,13 +2,10 @@ mod array;
 mod bytes;
 mod map;
 
+pub use self::array::{Array, ArrayIntoIter, ArrayIter, TypedArray};
+pub use self::bytes::Bytes;
+pub use self::map::{Map, MapIter, MapValuesIntoIter, TypedMap};
 use crate::types::LhsValue;
-
-pub use self::{
-    array::{Array, ArrayIntoIter, ArrayIter, TypedArray},
-    bytes::Bytes,
-    map::{Map, MapIter, MapValuesIntoIter, TypedMap},
-};
 
 pub struct AsRefIterator<'a, T: Iterator<Item = &'a LhsValue<'a>>>(T);
 

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -79,49 +79,47 @@ mod searcher;
 mod strict_partial_ord;
 mod types;
 
-pub use self::{
-    ast::{
-        Expr, FilterAst, FilterValueAst, ValueExpr,
-        field_expr::{ComparisonExpr, ComparisonOpExpr, IdentifierExpr, IntOp, OrderingOp},
-        function_expr::{FunctionCallArgExpr, FunctionCallExpr},
-        index_expr::{Compare, IndexExpr},
-        logical_expr::{LogicalExpr, LogicalOp, ParenthesizedExpr, UnaryOp},
-        parse::{FilterParser, ParseError, ParserSettings},
-        visitor::{Visitor, VisitorMut},
-    },
-    compiler::{Compiler, DefaultCompiler},
-    execution_context::{
-        ExecutionContext, ExecutionContextGuard, InvalidListMatcherError, SetFieldValueError,
-    },
-    filter::{
-        CompiledExpr, CompiledOneExpr, CompiledValueExpr, CompiledVecExpr, Filter, FilterValue,
-    },
-    functions::{
-        AllFunction, AnyFunction, ConcatFunction, FunctionArgInvalidConstantError, FunctionArgKind,
-        FunctionArgKindMismatchError, FunctionArgs, FunctionDefinition, FunctionDefinitionContext,
-        FunctionParam, FunctionParamError, SimpleFunctionArgKind, SimpleFunctionDefinition,
-        SimpleFunctionImpl, SimpleFunctionOptParam, SimpleFunctionParam,
-    },
-    lex::LexErrorKind,
-    lhs_types::{Array, Bytes, Map, MapIter, TypedArray, TypedMap},
-    list_matcher::{
-        AlwaysList, AlwaysListMatcher, ListDefinition, ListMatcher, NeverList, NeverListMatcher,
-    },
-    panic::{
-        PanicCatcherFallbackMode, catch_panic, panic_catcher_disable, panic_catcher_enable,
-        panic_catcher_get_backtrace, panic_catcher_set_fallback_mode, panic_catcher_set_hook,
-    },
-    rhs_types::{
-        BytesExpr, BytesFormat, ExplicitIpRange, IntRange, IpCidr, IpRange, Regex, RegexError,
-        RegexFormat,
-    },
-    scheme::{
-        Field, FieldIndex, FieldRedefinitionError, FieldRef, Function, FunctionRedefinitionError,
-        FunctionRef, IdentifierRedefinitionError, IndexAccessError, List, ListRef, Scheme,
-        SchemeBuilder, SchemeMismatchError, UnknownFieldError,
-    },
-    types::{
-        CompoundType, ExpectedType, ExpectedTypeList, GetType, LhsValue, RhsValue, RhsValues, Type,
-        TypeMismatchError,
-    },
+pub use self::ast::field_expr::{
+    ComparisonExpr, ComparisonOpExpr, IdentifierExpr, IntOp, OrderingOp,
+};
+pub use self::ast::function_expr::{FunctionCallArgExpr, FunctionCallExpr};
+pub use self::ast::index_expr::{Compare, IndexExpr};
+pub use self::ast::logical_expr::{LogicalExpr, LogicalOp, ParenthesizedExpr, UnaryOp};
+pub use self::ast::parse::{FilterParser, ParseError, ParserSettings};
+pub use self::ast::visitor::{Visitor, VisitorMut};
+pub use self::ast::{Expr, FilterAst, FilterValueAst, ValueExpr};
+pub use self::compiler::{Compiler, DefaultCompiler};
+pub use self::execution_context::{
+    ExecutionContext, ExecutionContextGuard, InvalidListMatcherError, SetFieldValueError,
+};
+pub use self::filter::{
+    CompiledExpr, CompiledOneExpr, CompiledValueExpr, CompiledVecExpr, Filter, FilterValue,
+};
+pub use self::functions::{
+    AllFunction, AnyFunction, ConcatFunction, FunctionArgInvalidConstantError, FunctionArgKind,
+    FunctionArgKindMismatchError, FunctionArgs, FunctionDefinition, FunctionDefinitionContext,
+    FunctionParam, FunctionParamError, SimpleFunctionArgKind, SimpleFunctionDefinition,
+    SimpleFunctionImpl, SimpleFunctionOptParam, SimpleFunctionParam,
+};
+pub use self::lex::LexErrorKind;
+pub use self::lhs_types::{Array, Bytes, Map, MapIter, TypedArray, TypedMap};
+pub use self::list_matcher::{
+    AlwaysList, AlwaysListMatcher, ListDefinition, ListMatcher, NeverList, NeverListMatcher,
+};
+pub use self::panic::{
+    PanicCatcherFallbackMode, catch_panic, panic_catcher_disable, panic_catcher_enable,
+    panic_catcher_get_backtrace, panic_catcher_set_fallback_mode, panic_catcher_set_hook,
+};
+pub use self::rhs_types::{
+    BytesExpr, BytesFormat, ExplicitIpRange, IntRange, IpCidr, IpRange, Regex, RegexError,
+    RegexFormat,
+};
+pub use self::scheme::{
+    Field, FieldIndex, FieldRedefinitionError, FieldRef, Function, FunctionRedefinitionError,
+    FunctionRef, IdentifierRedefinitionError, IndexAccessError, List, ListRef, Scheme,
+    SchemeBuilder, SchemeMismatchError, UnknownFieldError,
+};
+pub use self::types::{
+    CompoundType, ExpectedType, ExpectedTypeList, GetType, LhsValue, RhsValue, RhsValues, Type,
+    TypeMismatchError,
 };

--- a/engine/src/list_matcher.rs
+++ b/engine/src/list_matcher.rs
@@ -1,5 +1,4 @@
-use crate::LhsValue;
-use crate::Type;
+use crate::{LhsValue, Type};
 use dyn_clone::DynClone;
 use serde::{Deserialize, Serialize};
 use std::any::Any;

--- a/engine/src/range_set.rs
+++ b/engine/src/range_set.rs
@@ -1,4 +1,7 @@
-use std::{borrow::Borrow, cmp::Ordering, iter::FromIterator, ops::RangeInclusive};
+use std::borrow::Borrow;
+use std::cmp::Ordering;
+use std::iter::FromIterator;
+use std::ops::RangeInclusive;
 
 /// RangeSet provides a set-like interface that allows to search for items while
 /// being constructed from and storing inclusive ranges in a compact fashion.

--- a/engine/src/rhs_types/array.rs
+++ b/engine/src/rhs_types/array.rs
@@ -1,11 +1,10 @@
-use crate::{
-    lex::{Lex, LexResult},
-    lhs_types::Array,
-    strict_partial_ord::StrictPartialOrd,
-    types::{GetType, Type},
-};
+use crate::lex::{Lex, LexResult};
+use crate::lhs_types::Array;
+use crate::strict_partial_ord::StrictPartialOrd;
+use crate::types::{GetType, Type};
 use serde::Serialize;
-use std::{borrow::Borrow, cmp::Ordering};
+use std::borrow::Borrow;
+use std::cmp::Ordering;
 
 /// [Uninhabited / empty type](https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types)
 /// for `array` with traits we need for RHS values.

--- a/engine/src/rhs_types/bool.rs
+++ b/engine/src/rhs_types/bool.rs
@@ -1,9 +1,8 @@
-use crate::{
-    lex::{Lex, LexResult},
-    strict_partial_ord::StrictPartialOrd,
-};
+use crate::lex::{Lex, LexResult};
+use crate::strict_partial_ord::StrictPartialOrd;
 use serde::Serialize;
-use std::{borrow::Borrow, cmp::Ordering};
+use std::borrow::Borrow;
+use std::cmp::Ordering;
 
 /// [Uninhabited / empty type](https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types)
 /// for `bool` with traits we need for RHS values.

--- a/engine/src/rhs_types/bytes.rs
+++ b/engine/src/rhs_types/bytes.rs
@@ -1,14 +1,10 @@
-use crate::{
-    lex::{Lex, LexErrorKind, LexResult, take},
-    strict_partial_ord::StrictPartialOrd,
-};
+use crate::lex::{Lex, LexErrorKind, LexResult, take};
+use crate::strict_partial_ord::StrictPartialOrd;
 use serde::{Serialize, Serializer};
-use std::{
-    fmt::{self, Debug, Formatter},
-    hash::{Hash, Hasher},
-    ops::Deref,
-    str,
-};
+use std::fmt::{self, Debug, Formatter};
+use std::hash::{Hash, Hasher};
+use std::ops::Deref;
+use std::str;
 
 /// BytesFormat describes the format in which the string was expressed
 #[derive(PartialEq, Eq, Copy, Clone)]

--- a/engine/src/rhs_types/bytes.rs
+++ b/engine/src/rhs_types/bytes.rs
@@ -147,8 +147,8 @@ impl AsRef<[u8]> for BytesExpr {
 }
 
 impl<'a> IntoIterator for &'a BytesExpr {
-    type Item = &'a u8;
     type IntoIter = std::slice::Iter<'a, u8>;
+    type Item = &'a u8;
 
     #[inline]
     fn into_iter(self) -> std::slice::Iter<'a, u8> {

--- a/engine/src/rhs_types/int.rs
+++ b/engine/src/rhs_types/int.rs
@@ -1,7 +1,5 @@
-use crate::{
-    lex::{Lex, LexErrorKind, LexResult, expect, span, take_while},
-    strict_partial_ord::StrictPartialOrd,
-};
+use crate::lex::{Lex, LexErrorKind, LexResult, expect, span, take_while};
+use crate::strict_partial_ord::StrictPartialOrd;
 use serde::Serialize;
 use std::ops::RangeInclusive;
 

--- a/engine/src/rhs_types/ip.rs
+++ b/engine/src/rhs_types/ip.rs
@@ -1,17 +1,13 @@
+use crate::lex::{Lex, LexError, LexErrorKind, LexResult, take_while};
+use crate::strict_partial_ord::StrictPartialOrd;
 pub use cidr::IpCidr;
-
-use crate::{
-    lex::{Lex, LexError, LexErrorKind, LexResult, take_while},
-    strict_partial_ord::StrictPartialOrd,
-};
-use cidr::{Ipv4Cidr, Ipv6Cidr, errors::NetworkParseError};
+use cidr::errors::NetworkParseError;
+use cidr::{Ipv4Cidr, Ipv6Cidr};
 use serde::Serialize;
-use std::{
-    cmp::Ordering,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr},
-    ops::RangeInclusive,
-    str::FromStr,
-};
+use std::cmp::Ordering;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::ops::RangeInclusive;
+use std::str::FromStr;
 
 fn match_addr_or_cidr(input: &str) -> LexResult<'_, &str> {
     take_while(

--- a/engine/src/rhs_types/map.rs
+++ b/engine/src/rhs_types/map.rs
@@ -1,11 +1,10 @@
-use crate::{
-    lex::{Lex, LexResult},
-    lhs_types::Map,
-    strict_partial_ord::StrictPartialOrd,
-    types::{GetType, Type},
-};
+use crate::lex::{Lex, LexResult};
+use crate::lhs_types::Map;
+use crate::strict_partial_ord::StrictPartialOrd;
+use crate::types::{GetType, Type};
 use serde::Serialize;
-use std::{borrow::Borrow, cmp::Ordering};
+use std::borrow::Borrow;
+use std::cmp::Ordering;
 
 /// [Uninhabited / empty type](https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types)
 /// for `map` with traits we need for RHS values.

--- a/engine/src/rhs_types/mod.rs
+++ b/engine/src/rhs_types/mod.rs
@@ -8,14 +8,12 @@ mod map;
 mod regex;
 mod wildcard;
 
-pub use self::{
-    array::UninhabitedArray,
-    bool::UninhabitedBool,
-    bytes::{BytesExpr, BytesFormat},
-    int::IntRange,
-    ip::{ExplicitIpRange, IpCidr, IpRange},
-    list::ListName,
-    map::UninhabitedMap,
-    regex::{Error as RegexError, Regex, RegexFormat},
-    wildcard::{Wildcard, WildcardError},
-};
+pub use self::array::UninhabitedArray;
+pub use self::bool::UninhabitedBool;
+pub use self::bytes::{BytesExpr, BytesFormat};
+pub use self::int::IntRange;
+pub use self::ip::{ExplicitIpRange, IpCidr, IpRange};
+pub use self::list::ListName;
+pub use self::map::UninhabitedMap;
+pub use self::regex::{Error as RegexError, Regex, RegexFormat};
+pub use self::wildcard::{Wildcard, WildcardError};

--- a/engine/src/rhs_types/regex/imp_real.rs
+++ b/engine/src/rhs_types/regex/imp_real.rs
@@ -1,8 +1,7 @@
-use regex_automata::MatchKind;
-use regex_automata::nfa::thompson::WhichCaptures;
-
 use super::Error;
 use crate::{ParserSettings, RegexFormat};
+use regex_automata::MatchKind;
+use regex_automata::nfa::thompson::WhichCaptures;
 use std::ops::Deref;
 use std::sync::Arc;
 

--- a/engine/src/rhs_types/regex/imp_stub.rs
+++ b/engine/src/rhs_types/regex/imp_stub.rs
@@ -1,6 +1,5 @@
-use thiserror::Error;
-
 use crate::{FilterParser, RegexFormat};
+use thiserror::Error;
 
 /// Dummy regex error.
 #[derive(Debug, PartialEq, Error)]

--- a/engine/src/rhs_types/wildcard.rs
+++ b/engine/src/rhs_types/wildcard.rs
@@ -2,10 +2,8 @@ use crate::lex::{LexResult, LexWith};
 use crate::rhs_types::bytes::{BytesExpr, lex_quoted_or_raw_string};
 use crate::{FilterParser, LexErrorKind};
 use serde::{Serialize, Serializer};
-use std::{
-    fmt::{self, Debug, Formatter},
-    hash::{Hash, Hasher},
-};
+use std::fmt::{self, Debug, Formatter};
+use std::hash::{Hash, Hasher};
 use thiserror::Error;
 use wildcard::WildcardToken;
 

--- a/engine/src/scheme.rs
+++ b/engine/src/scheme.rs
@@ -1,26 +1,20 @@
-use crate::{
-    ast::{
-        FilterAst, FilterValueAst,
-        parse::{FilterParser, ParseError, ParserSettings},
-    },
-    functions::FunctionDefinition,
-    lex::{Lex, LexErrorKind, LexResult, LexWith, expect, span, take_while},
-    list_matcher::ListDefinition,
-    types::{GetType, RhsValue, Type},
-};
+use crate::ast::parse::{FilterParser, ParseError, ParserSettings};
+use crate::ast::{FilterAst, FilterValueAst};
+use crate::functions::FunctionDefinition;
+use crate::lex::{Lex, LexErrorKind, LexResult, LexWith, expect, span, take_while};
+use crate::list_matcher::ListDefinition;
+use crate::types::{GetType, RhsValue, Type};
 use fnv::FnvBuildHasher;
 use serde::de::Visitor;
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::HashMap;
 use std::collections::hash_map::Entry;
+use std::convert::TryFrom;
+use std::fmt::{self, Debug, Formatter};
+use std::hash::{Hash, Hasher};
+use std::iter::Iterator;
 use std::sync::Arc;
-use std::{
-    collections::HashMap,
-    convert::TryFrom,
-    fmt::{self, Debug, Formatter},
-    hash::{Hash, Hasher},
-    iter::Iterator,
-};
 use thiserror::Error;
 
 /// An error that occurs if two underlying [schemes](struct@Scheme)
@@ -1270,7 +1264,8 @@ fn test_parse_error() {
 fn test_parse_error_in_op() {
     use cidr::errors::NetworkParseError;
     use indoc::indoc;
-    use std::{net::IpAddr, str::FromStr};
+    use std::net::IpAddr;
+    use std::str::FromStr;
 
     let scheme = &Scheme! {
         num: Int,

--- a/engine/src/searcher.rs
+++ b/engine/src/searcher.rs
@@ -1,7 +1,6 @@
+use crate::{Compare, ExecutionContext, LhsValue};
 use memchr::memmem::{Finder, FinderBuilder};
 use sliceslice::MemchrSearcher;
-
-use crate::{Compare, ExecutionContext, LhsValue};
 
 pub struct EmptySearcher;
 

--- a/engine/src/types.rs
+++ b/engine/src/types.rs
@@ -1,20 +1,18 @@
-use crate::{
-    lex::{Lex, LexResult, LexWith, expect, skip_space},
-    lhs_types::{Array, ArrayIntoIter, ArrayIter, Bytes, Map, MapIter, MapValuesIntoIter},
-    rhs_types::{BytesExpr, IntRange, IpRange, UninhabitedArray, UninhabitedBool, UninhabitedMap},
-    scheme::{FieldIndex, IndexAccessError},
-    strict_partial_ord::StrictPartialOrd,
+use crate::lex::{Lex, LexResult, LexWith, expect, skip_space};
+use crate::lhs_types::{Array, ArrayIntoIter, ArrayIter, Bytes, Map, MapIter, MapValuesIntoIter};
+use crate::rhs_types::{
+    BytesExpr, IntRange, IpRange, UninhabitedArray, UninhabitedBool, UninhabitedMap,
 };
+use crate::scheme::{FieldIndex, IndexAccessError};
+use crate::strict_partial_ord::StrictPartialOrd;
 use serde::de::{DeserializeSeed, Deserializer};
 use serde::{Deserialize, Serialize, Serializer};
-use std::{
-    cmp::Ordering,
-    collections::BTreeSet,
-    convert::TryFrom,
-    fmt::{self, Debug, Formatter},
-    iter::once,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr},
-};
+use std::cmp::Ordering;
+use std::collections::BTreeSet;
+use std::convert::TryFrom;
+use std::fmt::{self, Debug, Formatter};
+use std::iter::once;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use thiserror::Error;
 
 fn lex_rhs_values<'i, T: Lex<'i>>(input: &'i str) -> LexResult<'i, Vec<T>> {

--- a/engine/src/types.rs
+++ b/engine/src/types.rs
@@ -138,7 +138,7 @@ pub struct TypeMismatchError {
 }
 
 macro_rules! replace_underscore {
-    ($name:ident ($val_ty:ty)) => {
+    ($name:ident($val_ty:ty)) => {
         Type::$name(_)
     };
     ($name:ident) => {
@@ -859,8 +859,9 @@ impl ExactSizeIterator for IntoIter<'_> {
 }
 
 impl<'a> IntoIterator for LhsValue<'a> {
-    type Item = LhsValue<'a>;
     type IntoIter = IntoIter<'a>;
+    type Item = LhsValue<'a>;
+
     fn into_iter(self) -> Self::IntoIter {
         match self {
             LhsValue::Array(array) => IntoIter::IntoArray(array.into_iter()),

--- a/ffi/src/cstring.rs
+++ b/ffi/src/cstring.rs
@@ -1,8 +1,6 @@
-use std::{
-    fmt::{self, Debug},
-    io,
-    os::raw::c_char,
-};
+use std::fmt::{self, Debug};
+use std::io;
+use std::os::raw::c_char;
 
 /// Used for replacing null bytes in C strings that cannot contain null bytes.
 const SUBSTITUTE_BYTE: u8 = 0x1a;

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -10,13 +10,11 @@ use libc::c_char;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::de::DeserializeSeed;
 use std::cell::RefCell;
+use std::convert::TryFrom;
+use std::hash::Hasher;
+use std::io::{self, Write};
+use std::net::IpAddr;
 use std::ops::{Deref, DerefMut};
-use std::{
-    convert::TryFrom,
-    hash::Hasher,
-    io::{self, Write},
-    net::IpAddr,
-};
 use wirefilter::{AlwaysList, GetType, NeverList, Type, catch_panic};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -172,7 +172,7 @@ macro_rules! wrap_type {
     };
 }
 
-/* Wrapper types needed by cbindgen to forward declare opaque structs */
+// Wrapper types needed by cbindgen to forward declare opaque structs
 
 #[derive(Debug, Default)]
 #[repr(Rust)]
@@ -668,9 +668,8 @@ pub struct MatchingResult {
 }
 
 impl MatchingResult {
-    #[cfg(test)]
-    const MISSED: Self = Self {
-        status: Status::Success,
+    const ERROR: Self = Self {
+        status: Status::Error,
         matched: false,
     };
     #[cfg(test)]
@@ -678,8 +677,9 @@ impl MatchingResult {
         status: Status::Success,
         matched: true,
     };
-    const ERROR: Self = Self {
-        status: Status::Error,
+    #[cfg(test)]
+    const MISSED: Self = Self {
+        status: Status::Success,
         matched: false,
     };
     const PANIC: Self = Self {
@@ -724,6 +724,14 @@ pub struct UsingResult {
 }
 
 impl UsingResult {
+    const ERROR: Self = Self {
+        status: Status::Error,
+        used: false,
+    };
+    const PANIC: Self = Self {
+        status: Status::Error,
+        used: false,
+    };
     #[cfg(test)]
     const UNUSED: Self = Self {
         status: Status::Success,
@@ -733,14 +741,6 @@ impl UsingResult {
     const USED: Self = Self {
         status: Status::Success,
         used: true,
-    };
-    const ERROR: Self = Self {
-        status: Status::Error,
-        used: false,
-    };
-    const PANIC: Self = Self {
-        status: Status::Error,
-        used: false,
     };
 }
 

--- a/fuzz/map-keys/src/main.rs
+++ b/fuzz/map-keys/src/main.rs
@@ -1,5 +1,4 @@
 use std::sync::LazyLock;
-
 use wirefilter::{
     FunctionArgs, LhsValue, SimpleFunctionArgKind, SimpleFunctionDefinition, SimpleFunctionImpl,
     SimpleFunctionParam, Type,

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,5 @@
-format_doc_comments = true
-merge_imports = true
+format_code_in_doc_comments = true
+imports_granularity = "Crate"
 normalize_comments = true
 normalize_doc_attributes = true
 wrap_comments = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,9 @@
 format_code_in_doc_comments = true
-imports_granularity = "Crate"
+format_macro_matchers = true
+group_imports = "One"
+imports_granularity = "Module"
 normalize_comments = true
 normalize_doc_attributes = true
-wrap_comments = true
+reorder_impl_items = true
+use_field_init_shorthand = true
+use_try_shorthand = true


### PR DESCRIPTION
Some of the defined options are nightly only & some have been renamed/replaced:
- `format_doc_comments` renamed to `format_code_in_doc_comments`
- `merge_imports` replaced with `imports_granularity = "Crate"`
- Removed `wrap_comments` option as it causes a lot of changes & decreases readability of the comments.
- Added some more options to format more sections